### PR TITLE
Low level baskets interface

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -29,3 +29,4 @@
 | exception raising!                                                        | **no!** |
 | informational methods (keys/branches listings)                            | **partial** |
 | partitioning routines                                                     | &#x2713; |
+| low-level TBranch.baskets interface                                       | **no!** |

--- a/uproot/_walker/walker.py
+++ b/uproot/_walker/walker.py
@@ -18,8 +18,6 @@ import struct
 
 import numpy
 
-import uproot.const
-
 class Walker(object):
     def __init__(self, *args, **kwds):
         raise TypeError("Walker is an abstract class")
@@ -36,25 +34,3 @@ class Walker(object):
 
     def startcontext(self):
         pass
-
-    def readversion(self):
-        bcnt, vers = self.readfields("!IH")
-        bcnt = int(numpy.int64(bcnt) & ~uproot.const.kByteCountMask)
-        if bcnt == 0:
-            raise IOError("readversion byte count is zero")
-        return vers, bcnt
-
-    def skipversion(self):
-        version = self.readfield("!h")
-        if numpy.int64(version) & uproot.const.kByteCountVMask:
-            self.skip("!hh")
-
-    def skiptobject(self):
-        id, bits = self.readfields("!II")
-        bits = numpy.uint32(bits) | uproot.const.kIsOnHeap
-        if bits & uproot.const.kIsReferenced:
-            self.skip("!H")
-
-    def skipbcnt(self):
-        vers, bcnt = self.readversion()
-        self.skip(bcnt + 4 - 6)

--- a/uproot/core.py
+++ b/uproot/core.py
@@ -24,12 +24,12 @@ class TObjArray(uproot.rootio.Deserialized):
     def __init__(self, filewalker, walker):
         walker.startcontext()
         start = walker.index
-        vers, bcnt = walker.readversion()
+        vers, bcnt = self._readversion(walker)
 
         if vers >= 3:
             # TObjArray is a TObject
-            walker.skipversion()
-            walker.skiptobject()
+            self._skipversion(walker)
+            self._skiptobject(walker)
 
         if vers >= 2:
             # TObjArray is a not a TObject
@@ -64,9 +64,9 @@ class TNamed(uproot.rootio.Deserialized):
     def __init__(self, filewalker, walker):
         walker.startcontext()
         start = walker.index
-        vers, bcnt = walker.readversion()
-        walker.skipversion()
-        walker.skiptobject()
+        vers, bcnt = self._readversion(walker)
+        self._skipversion(walker)
+        self._skiptobject(walker)
 
         self.name = walker.readstring()
         self.title = walker.readstring()
@@ -79,7 +79,7 @@ class TAttLine(uproot.rootio.Deserialized):
     def __init__(self, filewalker, walker):
         walker.startcontext()
         start = walker.index
-        vers, bcnt = walker.readversion()
+        vers, bcnt = self._readversion(walker)
         walker.skip("!hhh")  # color, style, width
         self._checkbytecount(walker.index - start, bcnt)
 
@@ -89,7 +89,7 @@ class TAttFill(uproot.rootio.Deserialized):
     def __init__(self, filewalker, walker):
         walker.startcontext()
         start = walker.index
-        vers, bcnt = walker.readversion()
+        vers, bcnt = self._readversion(walker)
         walker.skip("!hh")  # color, style
         self._checkbytecount(walker.index - start, bcnt)
 
@@ -99,18 +99,6 @@ class TAttMarker(uproot.rootio.Deserialized):
     def __init__(self, filewalker, walker):
         walker.startcontext()
         start = walker.index
-        vers, bcnt = walker.readversion()
+        vers, bcnt = self._readversion(walker)
         walker.skip("!hhf")  # color, style, width
         self._checkbytecount(walker.index - start, bcnt)
-
-class TList(uproot.rootio.Deserialized):
-    """Represents a TList; implemented only because it's sometimes in TTree member data.
-    """
-    def __init__(self, filewalker, walker):
-        walker.startcontext()
-        start = walker.index
-        vers, bcnt = walker.readversion()
-        walker.skip(int(bcnt + 4 - (walker.index - start)))
-        self._checkbytecount(walker.index - start, bcnt)
-
-uproot.rootio.Deserialized.classes[b"TList"] = TList

--- a/uproot/tree.py
+++ b/uproot/tree.py
@@ -64,7 +64,7 @@ class TTree(uproot.core.TNamed,
     def __init__(self, filewalker, walker):
         walker.startcontext()
         start = walker.index
-        vers, bcnt = walker.readversion()
+        vers, bcnt = self._readversion(walker)
 
         uproot.core.TNamed.__init__(self, filewalker, walker)
         uproot.core.TAttLine.__init__(self, filewalker, walker)
@@ -500,7 +500,7 @@ class TBranch(uproot.core.TNamed,
     def __init__(self, filewalker, walker):
         walker.startcontext()
         start = walker.index
-        vers, bcnt = walker.readversion()
+        vers, bcnt = self._readversion(walker)
 
         if vers < 11:
             raise NotImplementedError("TBranch version too old")
@@ -513,7 +513,7 @@ class TBranch(uproot.core.TNamed,
 
         self.branches = list(uproot.core.TObjArray(filewalker, walker))
         self.leaves = list(uproot.core.TObjArray(filewalker, walker))
-        walker.skipbcnt() # reading baskets is expensive and useless
+        self._skipbcnt(walker) # reading baskets is expensive and useless
 
         walker.skip(1)  # isArray
         self._basketBytes = walker.readarray(">i4", maxBaskets)[:writeBasket]
@@ -1083,7 +1083,7 @@ class TBranchElement(TBranch):
     def __init__(self, filewalker, walker):
         walker.startcontext()
         start = walker.index
-        vers, bcnt = walker.readversion()
+        vers, bcnt = self._readversion(walker)
 
         if vers < 9:
             raise NotImplementedError("TBranchElement version too old")
@@ -1141,7 +1141,7 @@ class TLeaf(uproot.core.TNamed):
     def __init__(self, filewalker, walker):
         walker.startcontext()
         start = walker.index
-        vers, bcnt = walker.readversion()
+        vers, bcnt = self._readversion(walker)
 
         uproot.core.TNamed.__init__(self, filewalker, walker)
 
@@ -1169,7 +1169,7 @@ class {0}(TLeaf):
     def __init__(self, filewalker, walker):
         walker.startcontext()
         start = walker.index
-        vers, bcnt = walker.readversion()
+        vers, bcnt = self._readversion(walker)
 
         TLeaf.__init__(self, filewalker, walker)
 
@@ -1191,7 +1191,7 @@ class TLeafElement(TLeaf):
     def __init__(self, filewalker, walker):
         walker.startcontext()
         start = walker.index
-        vers, bcnt = walker.readversion()
+        vers, bcnt = self._readversion(walker)
 
         TLeaf.__init__(self, filewalker, walker)
 

--- a/uproot/version.py
+++ b/uproot/version.py
@@ -16,7 +16,7 @@
 
 import re
 
-__version__ = "1.3.1"
+__version__ = "1.4.0"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
Three features, actually:

   * `TBranch.baskets()` function to get data in a truly zero-copy way.
   * Moved ROOT-aware code from `Walker` into `Deserialized`; just a better separation of concerns.
   * If a class is unrecognized, skip past it and create an `Undefined` placeholder instead of raising an exception. This generalizes the solution to unhandled `TList`.

New version is 1.4.0. Need to start using continuous integration.