### PR TITLE
Add default argument for pandas.df

### DIFF
--- a/uproot/tree.py
+++ b/uproot/tree.py
@@ -562,7 +562,8 @@ class TTree(uproot.core.TNamed,
         import pandas
         connector = self._Connector()
 
-        def df(branchdtypes, executor=None, block=True):
+        def df(branchdtypes=None, executor=None, block=True):
+            branchdtypes = branchdtypes or self.branchnames
             toget = []
             for branch, dtype in self._normalizeselection(branchdtypes, self.allbranches):
                 toget.append((branch, dtype))


### PR DESCRIPTION
In this way it is possible to dump the whole TTree into a pandas
dataframe. The name of the branches are taken from self.branchnames.
No type information is used.