### PR TITLE
Add support for list and tuple subclasses in array functions.

### DIFF
--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -501,6 +501,26 @@ class TestTree(unittest.TestCase):
         self.assertEqual(arrays.one.tolist(), [1, 2, 3, 4])
         self.assertEqual(arrays.three.tolist(), [b"uno", b"dos", b"tres", b"quatro"])
 
+        class MyList(list):
+            pass
+
+        class MyTuple(tuple):
+            pass
+
+        arrays = tree.arrays(["three", "two", "one"], outputtype=MyList)
+        self.assertTrue(isinstance(arrays, MyList))
+        self.assertEqual(arrays[2].tolist(), [1, 2, 3, 4])
+        self.assertEqual(arrays[0].tolist(), [b"uno", b"dos", b"tres", b"quatro"])
+
+        arrays = tree.arrays(["three", "two", "one"], outputtype=MyTuple)
+        self.assertTrue(isinstance(arrays, MyTuple))
+
+        arrays = tree.lazyarrays(["three", "two", "one"], outputtype=MyList)
+        self.assertTrue(isinstance(arrays, MyList))
+
+        arrays = tree.lazyarrays(["three", "two", "one"], outputtype=MyTuple)
+        self.assertTrue(isinstance(arrays, MyTuple))
+
     def test_tree_lazy(self):
         tree = uproot.open("tests/samples/sample-5.30.00-uncompressed.root")["sample"]
 


### PR DESCRIPTION
Hi there,

first of all, uproot is great! I think this is going to be a game changer.

In a project, I'm using a subclass of `list` (just for a different repr implementation, nothing too fancy). Now, when I convert branches to arrays via

```python
tree = uproot.open("file.root")["myTree"]
arrays = tree.arrays(["branchA", "branchB"], objecttype=MyList)
```
my custom list gets the two arrays as arguments, rather than as another list or a generator since something like `objecttype(*[...])` is used internally. It would be very nice and transparent if subclasses of list and tuple were supported.

This PR contains the required changes and additional tests. I also used generator expressions to prevent copying of the constructor arguments.