### PR TITLE
Temp fixed a problem preventing JaggedArray from being pickled

### DIFF
--- a/uproot/interp/jagged.py
+++ b/uproot/interp/jagged.py
@@ -136,10 +136,7 @@ class asjagged(Interpretation):
         starts = offsets[:-1]
         stops  = offsets[1:]
         content = self.asdtype.finalize(destination.content, branch)
-        leafcount = None
-        if len(branch.fLeaves) == 1:
-            leafcount = branch.fLeaves[0].fLeafCount
-        return JaggedArray(content, starts, stops, leafcount=leafcount)
+        return JaggedArray(content, starts, stops)
 
 def asstlvector(asdtype):
     return asjagged(asdtype, skip_bytes=10)
@@ -215,7 +212,7 @@ class JaggedArray(object):
 
         return JaggedArray(content, starts, stops)
 
-    def __init__(self, content, starts, stops, leafcount=None):
+    def __init__(self, content, starts, stops):
         assert isinstance(content, numpy.ndarray)
         assert isinstance(starts, numpy.ndarray) and issubclass(starts.dtype.type, numpy.integer)
         assert isinstance(stops, numpy.ndarray) and issubclass(stops.dtype.type, numpy.integer)
@@ -224,7 +221,6 @@ class JaggedArray(object):
         self.content = content
         self.starts = starts
         self.stops = stops
-        self.leafcount = leafcount
 
     @property
     def offsets(self):
@@ -240,10 +236,7 @@ class JaggedArray(object):
             raise ValueError("starts and stops are not compatible; cannot express as offsets")
 
     def aligned(self, other):
-        if self.leafcount is not None and other.leafcount is not None and self.leafcount is other.leafcount:
-            return True
-        else:
-            return numpy.array_equal(self.starts, other.starts) and numpy.array_equal(self.stops, other.stops)
+        return numpy.array_equal(self.starts, other.starts) and numpy.array_equal(self.stops, other.stops)
 
     def __len__(self):
         return len(self.stops)


### PR DESCRIPTION
This is probably another tiny bug about the diskcache. It seems the JaggedArray class is not able to be pickled if generated by reading a rootfile (ok if from lists). I tested it with HZZ.root and some codes like this:
```
_disk_cache = uproot.cache.DiskCache.create(50 * 1024**3, _cache_dir)
_cache = uproot.cache.MemoryCache(8 * 1024**3, spillover=_disk_cache, spill_immediately=True)
tree = uproot.open('HZZ.root')['events']
muon_px = tree.arrays(["Muon_Px"], cache=_cache)
```
and the output is:
```
_pickle.PicklingError: Can't pickle <class 'uproot.rootio.TLeafI'>: attribute lookup TLeafI on uproot.rootio failed
```

Digging into the code, it seems that the leafcount attribute in JaggedArray is causing this problem since it saves a dynamically generated class. And pickle does not work very well with dynamic things. The only place leafcount is used is the JaggedArray.aligned() function and after a grep, I did not see any other place this function is called. So I removed this leafcount attribute as a temp work-around and aligned() can still be calculated by comparing starts and stops.

I might be wrong if this function is added on purpose. If so, just drop off this PR and fix it with a more decent way.

uproot is a great project! Thanks a lot!