### PR TITLE
Adding test and support for None for flatten

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ matrix:
       env: NUMPY="numpy==1.13.1"
 
 install:
+  - env
+  - echo $TRAVIS_PYTHON_VERSION
   - pip install --upgrade setuptools_scm
   - pip install $NUMPY
   - python -c 'import numpy; print(numpy.__version__)'
@@ -37,6 +39,7 @@ install:
   - python -c 'import awkward; print(awkward.__version__)'
   - pip install "uproot-methods>=0.2.0"
   - python -c 'import uproot_methods; print(uproot_methods.__version__)'
+  - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]] ; then pip install pandas ; fi
 
 addons:
   apt:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,4 +47,5 @@ build_script:
   - "pip install %NUMPY%"
   - "pip install uproot-methods>=0.2.0"
   - "pip install -i https://pypi.anaconda.org/carlkl/simple backports.lzma"
+  - "pip install pandas"
   - "python setup.py test"

--- a/tests/test_jagged.py
+++ b/tests/test_jagged.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2017, DIANA-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+import uproot
+try:
+    import pandas
+except ImportError:
+    pandas = None
+
+class Test(unittest.TestCase):
+    def setUp(self):
+        self.sample = uproot.open('tests/samples/sample-6.10.05-uncompressed.root')["sample"]
+
+    @unittest.skipIf(pandas is None, "Pandas not installed")
+    def test_flatten_False(self):
+        df = self.sample.pandas.df(flatten=False)
+        self.assertEqual(len(df.keys()), 57)
+        self.assertIn('Af8', df)
+        self.assertEqual(len(df.at[0,'Af8']), 0)
+        self.assertEqual(len(df.at[1,'Af8']), 1)
+        self.assertEqual(len(df.at[2,'Af8']), 2)
+
+    @unittest.skipIf(pandas is None, "Pandas not installed")
+    def test_flatten_None(self):
+        df = self.sample.pandas.df(flatten=None)
+        self.assertEqual(len(df.keys()), 46)
+        self.assertNotIn('Af8', df)
+
+    @unittest.skipIf(pandas is None, "Pandas not installed")
+    @unittest.expectedFailure
+    def test_flatten_True(self):
+        df = self.sample.pandas.df(flatten=True)
+        self.assertEquals(len(df.keys()), 57)
+        self.assertIn('Af8', df)
+        # Add tests when this starts working

--- a/uproot/_help.py
+++ b/uproot/_help.py
@@ -452,8 +452,8 @@ tree_fragments = {
         if ``False`` *(default)*, yield only arrays (as ``outputtype``); otherwise, yield 3-tuple: *(entry start, entry stop, arrays)*, where *entry start* is inclusive and *entry stop* is exclusive.""",
 
     # flatten
-    "flatten": u"""flatten : bool
-        if ``True`` *(not default)*, convert JaggedArrays into flat Numpy arrays.""",
+    "flatten": u"""flatten : None or bool
+        if ``True``, convert JaggedArrays into flat Numpy arrays. If False *(default)*, make JaggedArrays lists. If None, remove JaggedArrays.""",
 
     # cache
     "cache": u"""cache : ``None`` or ``dict``-like object
@@ -1416,8 +1416,8 @@ u"""Create a Pandas DataFrame from some branches.
 
     {entrystop}
 
-    flatten : bool
-        if ``True`` *(default)*, convert JaggedArrays into flat Numpy arrays and turn the DataFrame index into a two-level MultiIndex to represent the structure.
+    flatten : None or bool
+        if ``True`` *(default)*, convert JaggedArrays into flat Numpy arrays and turn the DataFrame index into a two-level MultiIndex to represent the structure. If False, make JaggedArrays into lists. If None, remove JaggedArrays.
 
     {cache}
 

--- a/uproot/tree.py
+++ b/uproot/tree.py
@@ -429,7 +429,7 @@ class TTreeMethods(object):
         entrystart, entrystop = self._normalize_entrystartstop(entrystart, entrystop)
 
         # start the job of filling the arrays
-        futures = [(branch.name if namedecode is None else branch.name.decode(namedecode), interpretation, branch.array(interpretation=interpretation, entrystart=entrystart, entrystop=entrystop, flatten=(flatten and not ispandas), cache=cache, basketcache=basketcache, keycache=keycache, executor=executor, blocking=False)) for branch, interpretation in branches]
+        futures = [(branch.name if namedecode is None else branch.name.decode(namedecode), interpretation, branch.array(interpretation=interpretation, entrystart=entrystart, entrystop=entrystop, flatten=(flatten and not ispandas), cache=cache, basketcache=basketcache, keycache=keycache, executor=executor, blocking=False)) for branch, interpretation in branches if not (isinstance(interpretation, asjagged) and flatten is None) ]
 
         # make functions that wait for the filling job to be done and return the right outputtype
         if outputtype == namedtuple:


### PR DESCRIPTION
This addresses #156 , it makes `flatten=None` a possible option when filtering; unlike `False`, this simply removes anything that would need flattening, rather than making them lists. It also adds an *expected failing* test for the current broken `flatten=True` behavior.