### PR TITLE
introduce a _branchlookup dict for faster lookups

### DIFF
--- a/uproot/version.py
+++ b/uproot/version.py
@@ -30,7 +30,7 @@
 
 import re
 
-__version__ = "3.2.3"
+__version__ = "3.2.4"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
 (one per TTree, NOT one per TBranch)

Fixes #164.
