### PR TITLE
Add all attributes when copying XRootDSource

### DIFF
--- a/uproot/source/xrootd.py
+++ b/uproot/source/xrootd.py
@@ -28,8 +28,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import os.path
-
 import numpy
 
 import uproot.source.chunked
@@ -72,6 +70,8 @@ class XRootDSource(uproot.source.chunked.ChunkedSource):
         out._chunkbytes = self._chunkbytes
         out.cache = self.cache
         out._source = None             # XRootD connections are *not shared* among threads
+        out._size = self._size
+        out.timeout = self.timeout
         return out
 
     def _read(self, chunkindex):


### PR DESCRIPTION
Fixes this (slightly edited) traceback that I got with uproot 3.2.9. I also dropped the unused `os.path` import.

```python
Traceback (most recent call last):
  File "/example/lib/python3.6/site-packages/cachetools/cache.py", line 51, in __getitem__
    return self.__data[key]
KeyError: 86

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/example/lib/python3.6/site-packages/uproot/source/chunked.py", line 84, in data
    chunk = self.cache[chunkindex]
  File "/example/lib/python3.6/site-packages/uproot/cache.py", line 79, in __getitem__
    return self._cache[where]
  File "/example/lib/python3.6/site-packages/cachetools/lru.py", line 16, in __getitem__
    value = cache_getitem(self, key)
  File "/example/lib/python3.6/site-packages/cachetools/cache.py", line 53, in __getitem__
    return self.__missing__(key)
  File "/example/lib/python3.6/site-packages/cachetools/cache.py", line 80, in __missing__
    value = self.__missing(key)
  File "/example/lib/python3.6/site-packages/cachetools/cache.py", line 110, in __missing
    raise KeyError(key)
KeyError: 86

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/example.py", line 61, in truth_match
    flatten=None
  File "/example/lib/python3.6/site-packages/uproot/_connect/to_pandas.py", line 46, in df
    return self._tree.arrays(branches=branches, outputtype=pandas.DataFrame, namedecode=namedecode, entrystart=entrystart, entrystop=entrystop, flatten=flatten, flatname=flatname, cache=cache, basketcache=basketcache, keycache=keycache, executor=executor, blocking=blocking)
  File "/example/lib/python3.6/site-packages/uproot/tree.py", line 448, in arrays
    futures = [(branch.name if namedecode is None else branch.name.decode(namedecode), interpretation, branch.array(interpretation=interpretation, entrystart=entrystart, entrystop=entrystop, flatten=(flatten and not ispandas), flatname=flatname, cache=cache, basketcache=basketcache, keycache=keycache, executor=executor, blocking=False)) for branch, interpretation in branches]
  File "/example/lib/python3.6/site-packages/uproot/tree.py", line 448, in <listcomp>
    futures = [(branch.name if namedecode is None else branch.name.decode(namedecode), interpretation, branch.array(interpretation=interpretation, entrystart=entrystart, entrystop=entrystop, flatten=(flatten and not ispandas), flatname=flatname, cache=cache, basketcache=basketcache, keycache=keycache, executor=executor, blocking=False)) for branch, interpretation in branches]
  File "/example/lib/python3.6/site-packages/uproot/tree.py", line 1309, in array
    _delayedraise(fill(j))
  File "/example/lib/python3.6/site-packages/uproot/tree.py", line 98, in _delayedraise
    raise err.with_traceback(trc)
  File "/example/lib/python3.6/site-packages/uproot/tree.py", line 1277, in fill
    source = self._basket(i, interpretation, local_entrystart, local_entrystop, basketcache, keycache)
  File "/example/lib/python3.6/site-packages/uproot/tree.py", line 1066, in _basket
    basketdata = key.basketdata()
  File "/example/lib/python3.6/site-packages/uproot/tree.py", line 1469, in basketdata
    return self.cursor.copied().bytes(datasource, self._fObjlen)
  File "/example/lib/python3.6/site-packages/uproot/source/cursor.py", line 78, in bytes
    return source.data(start, stop)
  File "/example/lib/python3.6/site-packages/uproot/source/chunked.py", line 86, in data
    self._open()
  File "/example/lib/python3.6/site-packages/uproot/source/xrootd.py", line 56, in _open
    status, dummy = self._source.open(self.path, timeout=(0 if self.timeout is None else self.timeout))
AttributeError: 'XRootDSource' object has no attribute 'timeout'
Exception ignored in: <bound method XRootDSource.__del__ of <uproot.source.xrootd.XRootDSource object at 0x7fc51c707fd0>>
Traceback (most recent call last):
  File "/example/lib/python3.6/site-packages/uproot/source/xrootd.py", line 86, in __del__
AttributeError: 'XRootDSource' object has no attribute 'timeout'
```
