### PR TITLE
Implemented std::bitset

### DIFF
--- a/uproot/interp/auto.py
+++ b/uproot/interp/auto.py
@@ -339,10 +339,7 @@ def interpret(branch, swapbytes=True, cntvers=False, tobject=True, speedbump=Tru
                 if hasattr(branch._streamer, "_fTypeName"):
                     m = re.match(b"bitset<([1-9][0-9]*)>", branch._streamer._fTypeName)
                     if m is not None:
-                        if branch._isTClonesArray:
-                            return asjagged(asstlbitset(int(m.group(1))), skipbytes=6)
-                        else:
-                            return asstlbitset(int(m.group(1)))
+                        return asjagged(asstlbitset(int(m.group(1))), skipbytes=6)
 
                 if getattr(branch._streamer, "_fTypeName", None) == b"vector<bool>":
                     return asjagged(asdtype(awkward.util.numpy.bool_), skipbytes=10)

--- a/uproot/interp/auto.py
+++ b/uproot/interp/auto.py
@@ -339,7 +339,10 @@ def interpret(branch, swapbytes=True, cntvers=False, tobject=True, speedbump=Tru
                 if hasattr(branch._streamer, "_fTypeName"):
                     m = re.match(b"bitset<([1-9][0-9]*)>", branch._streamer._fTypeName)
                     if m is not None:
-                        return asstlbitset(int(m.group(1)))
+                        if branch._isTClonesArray:
+                            return asjagged(asstlbitset(int(m.group(1))), skipbytes=6)
+                        else:
+                            return asstlbitset(int(m.group(1)))
 
                 if getattr(branch._streamer, "_fTypeName", None) == b"vector<bool>":
                     return asjagged(asdtype(awkward.util.numpy.bool_), skipbytes=10)

--- a/uproot/interp/auto.py
+++ b/uproot/interp/auto.py
@@ -309,7 +309,10 @@ def interpret(branch, swapbytes=True, cntvers=False, tobject=True, speedbump=Tru
                             ascontent = asdtype(fromdtype, fromdtype.newbyteorder("="))
                         else:
                             ascontent = asdtype(fromdtype, fromdtype)
-                        return asjagged(ascontent, skipbytes=10)
+                        if branch._isTClonesArray:
+                            return asjagged(ascontent, skipbytes=6)
+                        else:
+                            return asjagged(ascontent, skipbytes=10)
 
                     except _NotNumerical:
                         if branch._vecstreamer is not None:

--- a/uproot/interp/jagged.py
+++ b/uproot/interp/jagged.py
@@ -120,6 +120,8 @@ class asjagged(uproot.interp.interp.Interpretation):
                     sub = sub.content
                 if isinstance(sub, uproot.interp.numerical.asdtype):
                     itemsize = sub.fromdtype.itemsize
+                if isinstance(sub, uproot.interp.numerical.asstlbitset):
+                    itemsize = sub.numbytes + 4
 
                 counts = bytestops - bytestarts
                 shift = math.log(itemsize, 2)

--- a/uproot/interp/numerical.py
+++ b/uproot/interp/numerical.py
@@ -290,5 +290,46 @@ class asstlbitset(uproot.interp.interp.Interpretation):
     # makes __doc__ attribute mutable before Python 3.3
     __metaclass__ = type.__new__(type, "type", (uproot.interp.interp.Interpretation.__metaclass__,), {})
 
+    todtype = awkward.util.numpy.dtype(awkward.util.numpy.bool_)
+
+    def __init__(self, numbytes):
+        self.numbytes = numbytes
+
+    def __repr__(self):
+        return self.identifier
+
+    @property
+    def identifier(self):
+        return "asstlbitset({0})".format(self.numbytes)
+
+    @property
+    def type(self):
+        return awkward.type.ArrayType(self.numbytes, self.todtype)
+
+    def empty(self):
+        return awkward.util.numpy.empty((0, self.numbytes), dtype=self.todtype)
+
     def compatible(self, other):
-        return isinstance(other, asstlbitset) and self.numbytes == other.numbytes
+        return (isinstance(other, asstlbitset) and self.numbytes == other.numbytes) or \
+               (isinstance(other, (asdtype, asarray)) and self.todtype == other.todtype and (self.numbytes,) == other.todims)
+
+    def numitems(self, numbytes, numentries):
+        return max(0, numbytes // (self.numbytes + 4))
+
+    def source_numitems(self, source):
+        return int(awkward.util.numpy.prod(source.shape))
+
+    def fromroot(self, data, byteoffsets, local_entrystart, local_entrystop):
+        return data.view(self.todtype).reshape((-1, self.numbytes + 4))[:, 4:]
+
+    def destination(self, numitems, numentries):
+        return awkward.util.numpy.empty((numitems // self.numbytes, self.numbytes), dtype=self.todtype)
+
+    def fill(self, source, destination, itemstart, itemstop, entrystart, entrystop):
+        destination.reshape(-1)[itemstart:itemstop] = source.reshape(-1)
+
+    def clip(self, destination, itemstart, itemstop, entrystart, entrystop):
+        return destination[entrystart:entrystop]
+
+    def finalize(self, destination, branch):
+        return destination

--- a/uproot/interp/numerical.py
+++ b/uproot/interp/numerical.py
@@ -323,13 +323,13 @@ class asstlbitset(uproot.interp.interp.Interpretation):
         return data.view(self.todtype).reshape((-1, self.numbytes + 4))[:, 4:]
 
     def destination(self, numitems, numentries):
-        return awkward.util.numpy.empty((numitems // self.numbytes, self.numbytes), dtype=self.todtype)
+        return awkward.util.numpy.empty((numitems, self.numbytes), dtype=self.todtype)
 
     def fill(self, source, destination, itemstart, itemstop, entrystart, entrystop):
-        destination.reshape(-1)[itemstart:itemstop] = source.reshape(-1)
+        destination[itemstart:itemstop] = source
 
     def clip(self, destination, itemstart, itemstop, entrystart, entrystop):
-        return destination[entrystart:entrystop]
+        return destination[itemstart:itemstop]
 
     def finalize(self, destination, branch):
         return destination

--- a/uproot/version.py
+++ b/uproot/version.py
@@ -30,7 +30,7 @@
 
 import re
 
-__version__ = "3.2.10"
+__version__ = "3.2.11"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
Strangely, `std::bitset` was simply overlooked in the transition from uproot 2 to 3. The class was sitting there, empty. This PR implements it in the new framework and adds a check for branches inside a TClonesArray, which have a truncated header.