### PR TITLE
Fix moved array types.

### DIFF
--- a/uproot/interp/jagged.py
+++ b/uproot/interp/jagged.py
@@ -80,7 +80,7 @@ class asjagged(uproot.interp.interp.Interpretation):
         return awkward.type.ArrayType(awkward.util.numpy.inf, self.content.type)
 
     def empty(self):
-        return awkward.JaggedArray(awkward.util.numpy.empty(0, dtype=awkward.util.INDEXTYPE), awkward.util.numpy.empty(0, dtype=awkward.util.INDEXTYPE), self.content.empty())
+        return awkward.JaggedArray(awkward.util.numpy.empty(0, dtype=awkward.JaggedArray.INDEXTYPE), awkward.util.numpy.empty(0, dtype=awkward.JaggedArray.INDEXTYPE), self.content.empty())
 
     def compatible(self, other):
         return isinstance(other, asjagged) and self.content.compatible(other.content)
@@ -130,7 +130,7 @@ class asjagged(uproot.interp.interp.Interpretation):
                 else:
                     awkward.util.numpy.floor_divide(counts, itemsize, out=counts)
 
-                offsets = awkward.util.numpy.empty(len(counts) + 1, awkward.util.INDEXTYPE)
+                offsets = awkward.util.numpy.empty(len(counts) + 1, awkward.JaggedArray.INDEXTYPE)
                 offsets[0] = 0
                 awkward.util.numpy.cumsum(counts, out=offsets[1:])
 
@@ -138,7 +138,7 @@ class asjagged(uproot.interp.interp.Interpretation):
 
     def destination(self, numitems, numentries):
         content = self.content.destination(numitems, numentries)
-        counts = awkward.util.numpy.empty(numentries, dtype=awkward.util.INDEXTYPE)
+        counts = awkward.util.numpy.empty(numentries, dtype=awkward.JaggedArray.INDEXTYPE)
         return _JaggedArrayPrep(counts, content)
 
     def fill(self, source, destination, itemstart, itemstop, entrystart, entrystop):

--- a/uproot/interp/objects.py
+++ b/uproot/interp/objects.py
@@ -93,7 +93,7 @@ class STLString(object):
 
     def read(self, source, cursor, context, parent):
         numitems = cursor.field(source, self._format1)
-        return cursor.array(source, numitems, awkward.array.base.AwkwardArray.CHARTYPE).tostring()
+        return cursor.array(source, numitems, awkward.ObjectArray.CHARTYPE).tostring()
 
 class astable(uproot.interp.interp.Interpretation):
     # makes __doc__ attribute mutable before Python 3.3
@@ -281,7 +281,7 @@ class asgenobj(_variable):
                 return repr(self.cls)
 
     def __init__(self, cls, context, skipbytes):
-        super(asgenobj, self).__init__(uproot.interp.jagged.asjagged(uproot.interp.numerical.asdtype(awkward.JaggedArray.CHARTYPE), skipbytes=skipbytes), asgenobj._Wrapper(cls, context))
+        super(asgenobj, self).__init__(uproot.interp.jagged.asjagged(uproot.interp.numerical.asdtype(awkward.ObjectArray.CHARTYPE), skipbytes=skipbytes), asgenobj._Wrapper(cls, context))
 
     def speedbump(self, value):
         out = copy.copy(self)
@@ -298,7 +298,7 @@ class asstring(_variable):
     __metaclass__ = type.__new__(type, "type", (_variable.__metaclass__,), {})
 
     def __init__(self, skipbytes=1):
-        super(asstring, self).__init__(uproot.interp.jagged.asjagged(uproot.interp.numerical.asdtype(awkward.JaggedArray.CHARTYPE), skipbytes=skipbytes), lambda array: array.tostring())
+        super(asstring, self).__init__(uproot.interp.jagged.asjagged(uproot.interp.numerical.asdtype(awkward.ObjectArray.CHARTYPE), skipbytes=skipbytes), lambda array: array.tostring())
 
     def __repr__(self):
         return "asstring({0})".format("" if self.content.skipbytes == 1 else repr(self.content.skipbytes))

--- a/uproot/interp/objects.py
+++ b/uproot/interp/objects.py
@@ -93,7 +93,7 @@ class STLString(object):
 
     def read(self, source, cursor, context, parent):
         numitems = cursor.field(source, self._format1)
-        return cursor.array(source, numitems, awkward.util.CHARTYPE).tostring()
+        return cursor.array(source, numitems, awkward.array.base.AwkwardArray.CHARTYPE).tostring()
 
 class astable(uproot.interp.interp.Interpretation):
     # makes __doc__ attribute mutable before Python 3.3
@@ -281,7 +281,7 @@ class asgenobj(_variable):
                 return repr(self.cls)
 
     def __init__(self, cls, context, skipbytes):
-        super(asgenobj, self).__init__(uproot.interp.jagged.asjagged(uproot.interp.numerical.asdtype(awkward.util.CHARTYPE), skipbytes=skipbytes), asgenobj._Wrapper(cls, context))
+        super(asgenobj, self).__init__(uproot.interp.jagged.asjagged(uproot.interp.numerical.asdtype(awkward.JaggedArray.CHARTYPE), skipbytes=skipbytes), asgenobj._Wrapper(cls, context))
 
     def speedbump(self, value):
         out = copy.copy(self)
@@ -298,7 +298,7 @@ class asstring(_variable):
     __metaclass__ = type.__new__(type, "type", (_variable.__metaclass__,), {})
 
     def __init__(self, skipbytes=1):
-        super(asstring, self).__init__(uproot.interp.jagged.asjagged(uproot.interp.numerical.asdtype(awkward.util.CHARTYPE), skipbytes=skipbytes), lambda array: array.tostring())
+        super(asstring, self).__init__(uproot.interp.jagged.asjagged(uproot.interp.numerical.asdtype(awkward.JaggedArray.CHARTYPE), skipbytes=skipbytes), lambda array: array.tostring())
 
     def __repr__(self):
         return "asstring({0})".format("" if self.content.skipbytes == 1 else repr(self.content.skipbytes))

--- a/uproot/version.py
+++ b/uproot/version.py
@@ -30,7 +30,7 @@
 
 import re
 
-__version__ = "3.2.13"
+__version__ = "3.2.14"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
Hi Jim,

I ran into an error after a fresh install of uproot and awkward from latest pypi versions.
uproot complained about a missing `awkward.util.INDEXTYPE`.

I saw that you moved the types to the base AwkwardArray, and noticed that this change is not yet reflected here in uproot, so I did a quick replacement.

The changes in this PR use `awkward.JaggedArray` where jagged arrays are handled, and `awkward.array.base.AwkwardArray` otherwise.
