### PR TITLE
More histogram intro

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -881,15 +881,19 @@ We have to add functionality by writing the equivalent Python. The uproot `TTree
     [3, inf]     0    |                                                            |
                       +------------------------------------------------------------+
 
+Code to view histograms in Pythonic plotting packages is in development, but this is a wide-open area for future development. For now, uproot's ability to read histograms is useful for querying bin values in scripts, like so.
+
 .. code-block:: python
 
-    >>> [x for x in dir(file["one"]) if not x.startswith("_") and not x.startswith("f")]
-    ['allvalues', 'append', 'bokeh', 'classname', 'classversion', 'clear', 'copy', 'count',
-     'extend', 'high', 'holoviews', 'index', 'insert', 'interval', 'low', 'name', 'numbins',
-     'numpy', 'overflows', 'pop', 'read', 'remove', 'reverse', 'show', 'sort', 'title',
-     'underflows', 'values', 'xlabels']
+    >>> h = file["one"]
+    >>> h.edges  # returns a numpy array of bin edges, excluding under/overflow bins
+    [-3.0 -2.4 -1.8 -1.2 -0.6 0.0 0.6 1.2 1.8 2.4 3.0]
+    >>> h.values  # returns counter values, excluding *flow bins
+    [68 285 755 1580 2296 2286 1570 795 289 76]
+    >>> h.variances  # returns variance estimates, excluding *flow bins
+    [68 285 755 1580 2296 2286 1570 795 289 76]
 
-Code to view histograms in Pythonic plotting packages is in development, but this is a wide-open area for future development. For now, uproot's ability to read histograms is useful for querying bin values in scripts.
+There are corresponding fields `alledges`, `allvalues`, and `allvariances`, which include the under/overflow bins.
 
 Caching data
 ------------

--- a/README.rst
+++ b/README.rst
@@ -887,13 +887,15 @@ Code to view histograms in Pythonic plotting packages is in development, but thi
 
     >>> h = file["one"]
     >>> h.edges  # returns a numpy array of bin edges, excluding under/overflow bins
-    [-3.0 -2.4 -1.8 -1.2 -0.6 0.0 0.6 1.2 1.8 2.4 3.0]
+    array([-3. , -2.4, -1.8, -1.2, -0.6,  0. ,  0.6,  1.2,  1.8,  2.4,  3. ])
     >>> h.values  # returns counter values, excluding *flow bins
-    [68 285 755 1580 2296 2286 1570 795 289 76]
-    >>> h.variances  # returns variance estimates, excluding *flow bins
-    [68 285 755 1580 2296 2286 1570 795 289 76]
+    array([  68.,  285.,  755., 1580., 2296., 2286., 1570.,  795.,  289.,
+             76.], dtype=float32)
+    >>> h.variances  # returns counter variances for weighted histogram (*flow bins excluded)
+    h.variances
+    array([], dtype=float64)
 
-There are corresponding fields `alledges`, `allvalues`, and `allvariances`, which include the under/overflow bins.
+There are corresponding fields ``alledges``, ``allvalues``, and ``allvariances``, which include the under/overflow bins.
 
 Caching data
 ------------

--- a/README.rst
+++ b/README.rst
@@ -890,7 +890,7 @@ Code to view histograms in Pythonic plotting packages is in development, but thi
     array([-3. , -2.4, -1.8, -1.2, -0.6,  0. ,  0.6,  1.2,  1.8,  2.4,  3. ])
     >>> h.values     # returns counter values, excluding *flow bins
     array([  68.,  285.,  755., 1580., 2296., 2286., 1570.,  795.,  289., 76.], dtype=float32)
-    >>> h.variances  # returns counter variances for weighted histogram (*flow bins excluded)
+    >>> h.variances  # returns counter variances for weighted histograms (*flow bins excluded)
     array([], dtype=float64)
 
 There are corresponding fields ``alledges``, ``allvalues``, and ``allvariances``, which include the under/overflow bins.

--- a/README.rst
+++ b/README.rst
@@ -886,13 +886,11 @@ Code to view histograms in Pythonic plotting packages is in development, but thi
 .. code-block:: python
 
     >>> h = file["one"]
-    >>> h.edges  # returns a numpy array of bin edges, excluding under/overflow bins
+    >>> h.edges      # returns a numpy array of bin edges, excluding under/overflow bins
     array([-3. , -2.4, -1.8, -1.2, -0.6,  0. ,  0.6,  1.2,  1.8,  2.4,  3. ])
-    >>> h.values  # returns counter values, excluding *flow bins
-    array([  68.,  285.,  755., 1580., 2296., 2286., 1570.,  795.,  289.,
-             76.], dtype=float32)
+    >>> h.values     # returns counter values, excluding *flow bins
+    array([  68.,  285.,  755., 1580., 2296., 2286., 1570.,  795.,  289., 76.], dtype=float32)
     >>> h.variances  # returns counter variances for weighted histogram (*flow bins excluded)
-    h.variances
     array([], dtype=float64)
 
 There are corresponding fields ``alledges``, ``allvalues``, and ``allvariances``, which include the under/overflow bins.


### PR DESCRIPTION
Minimal extension of the README, which shows how to get the most important data of a histogram. Perhaps some link to uproot-methods should be added as well, to point to further information.