### PR TITLE
Limit numpy<1.16.0 in PyPy due to Travis CI release lag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ install:
   - echo $TRAVIS_PYTHON_VERSION
   - pip install --upgrade setuptools_scm
   - pip install $NUMPY
+    # FIXME: pypy bug in numpy
+  - if [[ $TRAVIS_PYTHON_VERSION = pypy* ]] ; then pip install "numpy<1.16.0" ; fi
   - python -c 'import numpy; print(numpy.__version__)'
   - pip install "awkward>=0.7.0"
   - python -c 'import awkward; print(awkward.__version__)'


### PR DESCRIPTION
In a Travis CI build I was working on for a different upcoming PR I noticed that the [PyPy releases were failing](https://travis-ci.org/scikit-hep/uproot/jobs/479246084). When this bug [was reported to Numpy](https://github.com/numpy/numpy/issues/12654) it was discovered that it seem to be an issue with the versions of PyPy that Travis CI has are old enough to be causing some issues. The [Travis CI response was to use a more recent version of PyPy](https://travis-ci.community/t/issue-travis-ci-fails-for-pypy-code-that-imports-numpy-1-16-0rc1/1680/2) such as `pypy2.7-6.0`.

This PR doesn't do that, but follows the approach that the original Issue reporter [took of limiting the version of NumPy used with the PyPy releases](https://github.com/uqfoundation/mystic/commit/44546990f40464ccbb5a99c00ec722bc6d41b9f7).

If different behavior is desired that can be implemented.