### PR TITLE
Http authentication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,8 @@ install:
   - pip install "uproot-methods>=0.3.0"
   - python -c 'import uproot_methods; print(uproot_methods.__version__)'
   - pip install pytest pytest-runner
+  - pip install lz4 requests
+  - if [[ $TRAVIS_PYTHON_VERSION = "2.7" ]] ; then pip install backports.lzma ; fi
   - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]] ; then pip install pandas ; fi
 
 addons:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,5 +48,5 @@ build_script:
   - "pip install awkward>=0.7.0"
   - "pip install uproot-methods>=0.3.0"
   - "pip install -i https://pypi.anaconda.org/carlkl/simple backports.lzma"
-  - "pip install pytest pytest-runner pandas"
+  - "pip install pytest pytest-runner pandas requests"
   - "python setup.py pytest"

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -6,3 +6,4 @@ pkgconfig
 lz4
 backports.lzma;python_version<"3.3"
 pandas
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ awkward>=0.7.0
 uproot-methods>=0.3.0
 cachetools
 backports.lzma;python_version<"3.3"
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ awkward>=0.7.0
 uproot-methods>=0.3.0
 cachetools
 backports.lzma;python_version<"3.3"
-requests

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ setup(name = "uproot",
       download_url = "https://github.com/scikit-hep/uproot/releases",
       license = "BSD 3-clause",
       test_suite = "tests",
-      install_requires = ["numpy>=1.13.1", "awkward>=0.7.0", "uproot-methods>=0.3.0", "cachetools"],
+      install_requires = ["numpy>=1.13.1", "awkward>=0.7.0", "uproot-methods>=0.3.0", "cachetools", "requests"],
       setup_requires = ["pytest-runner"],
       tests_require = ["pytest", "pkgconfig", "lz4", 'backports.lzma;python_version<"3.3"'],
       classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ setup(name = "uproot",
       download_url = "https://github.com/scikit-hep/uproot/releases",
       license = "BSD 3-clause",
       test_suite = "tests",
-      install_requires = ["numpy>=1.13.1", "awkward>=0.7.0", "uproot-methods>=0.3.0", "cachetools", "requests"],
+      install_requires = ["numpy>=1.13.1", "awkward>=0.7.0", "uproot-methods>=0.3.0", "cachetools"],
       setup_requires = ["pytest-runner"],
       tests_require = ["pytest", "pkgconfig", "lz4", 'backports.lzma;python_version<"3.3"'],
       classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(name = "uproot",
       test_suite = "tests",
       install_requires = ["numpy>=1.13.1", "awkward>=0.7.0", "uproot-methods>=0.3.0", "cachetools"],
       setup_requires = ["pytest-runner"],
-      tests_require = ["pytest", "pkgconfig", "lz4", 'backports.lzma;python_version<"3.3"'],
+      tests_require = ["pytest", "pkgconfig", "lz4", 'backports.lzma;python_version<"3.3"', "mock", "requests"],
       classifiers = [
           "Development Status :: 5 - Production/Stable",
           "Intended Audience :: Developers",

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -8,9 +8,9 @@ from requests.exceptions import HTTPError
 
 
 FILE = "foriter"
-LOCAL = f"tests/samples/{FILE}.root"
-URL = f"http://scikit-hep.org/uproot/examples/{FILE}.root"
-URL_AUTH = f"http://scikit-hep.org/uproot/authentication/{FILE}.root"
+LOCAL = "tests/samples/{FILE}.root".format(FILE=FILE)
+URL = "http://scikit-hep.org/uproot/examples/{FILE}.root".format(FILE=FILE)
+URL_AUTH = "http://scikit-hep.org/uproot/authentication/{FILE}.root".format(FILE=FILE)
 AUTH = ("scikit-hep", "uproot")
 
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -19,7 +19,7 @@ class Test(unittest.TestCase):
         assert type(f) == uproot.rootio.ROOTDirectory
 
     def test_auth_needed_no_auth(self):
-        with self.assertRaises(HTTPError) as context_manager:
+        with self.assertRaises(HTTPError):
             f = uproot.open(self.url_auth)
         assert context_manager.exception.response.status_code == 401
 
@@ -28,6 +28,6 @@ class Test(unittest.TestCase):
         assert type(f) == uproot.rootio.ROOTDirectory
 
     def test_auth_needed_wrong_auth(self):
-        with self.assertRaises(HTTPError) as context_manager:
+        with self.assertRaises(HTTPError):
             f = uproot.open(self.url_auth, httpsource={"auth": ("", "")})
         assert context_manager.exception.response.status_code == 401

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,0 +1,33 @@
+import unittest
+
+import uproot
+
+from requests.exceptions import HTTPError
+
+
+class Test(unittest.TestCase):
+    url = "http://scikit-hep.org/uproot/examples/HZZ.root"
+    url_auth = "http://scikit-hep.org/uproot/examples/HZZ.root"
+    auth = ("scikit-hep", "uproot")
+
+    def test_no_auth_needed_no_auth(self):
+        f = uproot.open(self.url)
+        assert type(f) == uproot.rootio.ROOTDirectory
+
+    def test_no_auth_needed_with_auth(self):
+        f = uproot.open(self.url, httpsource={"auth": self.auth})
+        assert type(f) == uproot.rootio.ROOTDirectory
+
+    def test_auth_needed_no_auth(self):
+        with self.assertRaises(HTTPError) as context_manager:
+            f = uproot.open(self.url_auth)
+        assert context_manager.exception.response.status_code == 401
+
+    def test_auth_needed_correct_auth(self):
+        f = uproot.open(self.url_auth, httpsource={"auth": self.auth})
+        assert type(f) == uproot.rootio.ROOTDirectory
+
+    def test_auth_needed_wrong_auth(self):
+        with self.assertRaises(HTTPError) as context_manager:
+            f = uproot.open(self.url_auth, httpsource={"auth": ("", "")})
+        assert context_manager.exception.response.status_code == 401

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,4 +1,5 @@
 import unittest
+import pytest
 
 import uproot
 
@@ -19,7 +20,7 @@ class Test(unittest.TestCase):
         assert type(f) == uproot.rootio.ROOTDirectory
 
     def test_auth_needed_no_auth(self):
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             f = uproot.open(self.url_auth)
         assert context_manager.exception.response.status_code == 401
 
@@ -28,6 +29,6 @@ class Test(unittest.TestCase):
         assert type(f) == uproot.rootio.ROOTDirectory
 
     def test_auth_needed_wrong_auth(self):
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             f = uproot.open(self.url_auth, httpsource={"auth": ("", "")})
         assert context_manager.exception.response.status_code == 401

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,34 +1,60 @@
 import unittest
 import pytest
+import mock
 
 import uproot
 
 from requests.exceptions import HTTPError
 
 
-class Test(unittest.TestCase):
-    url = "http://scikit-hep.org/uproot/examples/HZZ.root"
-    url_auth = "http://scikit-hep.org/uproot/examples/HZZ.root"
-    auth = ("scikit-hep", "uproot")
+FILE = "foriter"
+LOCAL = f"tests/samples/{FILE}.root"
+URL = f"http://scikit-hep.org/uproot/examples/{FILE}.root"
+URL_AUTH = f"http://scikit-hep.org/uproot/authentication/{FILE}.root"
+AUTH = ("scikit-hep", "uproot")
 
+
+def mock_get_local_instead_of_http(url="", headers={}, auth=None, **kwargs):
+    class MockResponse:
+        def __init__(self, status_code):
+            self.status_code = status_code
+            self.content = open(LOCAL, "br").read()
+            self.headers = {"Content-Range": str(len(self.content))}
+
+        def raise_for_status(self):
+            if self.status_code == 401:  # Authentication Error
+                raise HTTPError
+            elif self.status_code == 200:  # Ok
+                pass
+
+    if url == URL:
+        return MockResponse(200)
+    elif url == URL_AUTH and auth == None:
+        return MockResponse(401)
+    elif url == URL_AUTH and auth == AUTH:
+        return MockResponse(200)
+    elif url == URL_AUTH:
+        return MockResponse(401)
+
+
+@mock.patch("requests.get", mock_get_local_instead_of_http)
+class Test(unittest.TestCase):
     def test_no_auth_needed_no_auth(self):
-        f = uproot.open(self.url)
+        f = uproot.open(URL)
         assert type(f) == uproot.rootio.ROOTDirectory
 
     def test_no_auth_needed_with_auth(self):
-        f = uproot.open(self.url, httpsource={"auth": self.auth})
+        f = uproot.open(URL, httpsource={"auth": AUTH})
         assert type(f) == uproot.rootio.ROOTDirectory
 
     def test_auth_needed_no_auth(self):
         with pytest.raises(HTTPError):
-            f = uproot.open(self.url_auth)
-        assert context_manager.exception.response.status_code == 401
+            f = uproot.open(URL_AUTH)
 
     def test_auth_needed_correct_auth(self):
-        f = uproot.open(self.url_auth, httpsource={"auth": self.auth})
+        f = uproot.open(URL_AUTH, httpsource={"auth": AUTH})
         assert type(f) == uproot.rootio.ROOTDirectory
 
     def test_auth_needed_wrong_auth(self):
         with pytest.raises(HTTPError):
-            f = uproot.open(self.url_auth, httpsource={"auth": ("", "")})
-        assert context_manager.exception.response.status_code == 401
+            f = uproot.open(URL_AUTH, httpsource={"auth": ("", "")})

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -18,8 +18,9 @@ def mock_get_local_instead_of_http(url="", headers={}, auth=None, **kwargs):
     class MockResponse:
         def __init__(self, status_code):
             self.status_code = status_code
-            self.content = open(LOCAL, "br").read()
-            self.headers = {"Content-Range": str(len(self.content))}
+            if self.status_code == 200:
+                self.content = open(LOCAL, "rb").read()
+                self.headers = {"Content-Range": str(len(self.content))}
 
         def raise_for_status(self):
             if self.status_code == 401:  # Authentication Error

--- a/uproot/source/http.py
+++ b/uproot/source/http.py
@@ -30,7 +30,6 @@
 
 import os.path
 import re
-import requests
 
 import numpy
 
@@ -48,7 +47,10 @@ class HTTPSource(uproot.source.chunked.ChunkedSource):
     defaults = {"chunkbytes": 16*1024, "limitbytes": 16*1024**2}
 
     def _open(self):
-        pass
+        try:
+            import requests
+        except ImportError:
+            raise ImportError("\n\nInstall requests package (for HTTP) with:\n\n    pip install requests\nor\n    conda install -c anaconda requests")
 
     def size(self):
         return self._size
@@ -56,6 +58,7 @@ class HTTPSource(uproot.source.chunked.ChunkedSource):
     _contentrange = re.compile("^bytes ([0-9]+)-([0-9]+)/([0-9]+)$")
 
     def _read(self, chunkindex):
+        import requests
         response = requests.get(
             self.path,
             headers={"Range": "bytes={0}-{1}".format(chunkindex * self._chunkbytes, (chunkindex + 1) * self._chunkbytes)},

--- a/uproot/version.py
+++ b/uproot/version.py
@@ -30,7 +30,7 @@
 
 import re
 
-__version__ = "3.3.2"
+__version__ = "3.3.3"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
Resolves #210 

As suggested in #210 I implemented http authentication.
On the way I switched from urllib to [`requests`](http://docs.python-requests.org/en/master/).

Now i can do this:
```python
url = "http://data.magic.pic.es/Data/SuperStar/v1/CrabNebula/2014_01_01/20140101_05032025_S_CrabNebula-W0.40+035.root"
file = uproot.open(url, httpsource={"auth": ("username", "password")})
```
raising an `HTTPError` if the authentication is missing or wrong.

Opening non-protected files is the same as before.

The syntax for [authentication](http://docs.python-requests.org/en/master/user/authentication/#basic-authentication) is copied from requests.