### PR TITLE
Speedup TTree.pandas.df(flatten=True) by about factor 8

### DIFF
--- a/uproot/_connect/to_pandas.py
+++ b/uproot/_connect/to_pandas.py
@@ -140,7 +140,6 @@ def futures2df(futures, outputtype, entrystart, entrystop, flatten, flatname, aw
                         raise ValueError("cannot use flatten=True on branches with different jagged structure; explicitly select compatible branches (and pandas.merge if you want to combine different jagged structure)")
 
                 array = array.content
-                length = len(array)
                 needbroadcasts.append(False)
 
             else:

--- a/uproot/_connect/to_pandas.py
+++ b/uproot/_connect/to_pandas.py
@@ -150,9 +150,6 @@ def futures2df(futures, outputtype, entrystart, entrystop, flatten, flatname, aw
             interpretations.append(interpretation)
             arrays.append(array)
 
-        if length is None:
-            length = len(arrays[0])
-
         index = pandas.MultiIndex.from_arrays([index._broadcast(numpy.arange(entrystart, entrystop, dtype=numpy.int64)).content, index.content], names=["entry", "subentry"])
 
         df = outputtype(index=index)
@@ -174,8 +171,6 @@ def futures2df(futures, outputtype, entrystart, entrystop, flatten, flatname, aw
                     else:
                         if len(originaldims) != 0:
                             array = array.view(awkward.numpy.dtype([(str(i), array.dtype) for i in range(functools.reduce(operator.mul, array.shape[1:]))])).reshape(array.shape[0])
-
-                        print(name, starts, array)
 
                         array = awkward.JaggedArray(starts, stops, awkward.numpy.empty(stops[-1], dtype=array.dtype))._broadcast(array).content
                         if len(originaldims) != 0:

--- a/uproot/tree.py
+++ b/uproot/tree.py
@@ -464,7 +464,7 @@ class TTreeMethods(object):
         elif ispandas:
             import uproot._connect.to_pandas
             def wait():
-                return uproot._connect.to_pandas.futures2df(futures, outputtype, entrystart, entrystop, flatten, flatname)
+                return uproot._connect.to_pandas.futures2df(futures, outputtype, entrystart, entrystop, flatten, flatname, awkward)
 
         elif isinstance(outputtype, type) and issubclass(outputtype, dict):
             def wait():

--- a/uproot/version.py
+++ b/uproot/version.py
@@ -30,7 +30,7 @@
 
 import re
 
-__version__ = "3.4.3"
+__version__ = "3.4.4"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
Hi Jim!

I am working a little bit with the data analysis for the beam tests of the CMS endcap calorimeter upgrade, and we have ROOT files of the following pattern:
* Some branches with basic data types (`int`, `float`)
* Some branches with vectors, all the same length per event

I think the `TTree.pandas.df(flatten=True)` functionality is intended for this use case, but this is about 8 times slower than the equivalent functionality in root_pandas, which everyone therefore wants to use and has to go through the pain of installing ROOT. I realized the bottleneck of uproot is here in the merge:

https://github.com/scikit-hep/uproot/blob/master/uproot/_connect/to_pandas.py#L194

Pandas is very slow at merging DataFrames with MultiIndex and the normal Index together, which is happening there: for the basic type branches uproot creates simple DataFrames, for the vector branches DFs with MultiIndices.

It could be significantly sped up by turning the basic type branches into the correct structure by adding them to a JaggedArray of zeros (the broadcasting is just too useful). Additionally, if the broadcasting (or flattening for the awkward arrays) is done in a separate loop over the branches, one can save some code duplication when filling the data frame.

Therefore, this PR should still cover all usecases for `TTree.pandas.df(flatten=True)` but just be much faster. Actually a few ten % faster than root_numpy now. I tested it with an ntuple from the testbeam, with I uploaded here:
https://rembserj.web.cern.ch/rembserj/dumps/ntuple_426.root

What do you think about this? You think it goes in the right direction?

These are the speed benchmarks I did:

```Python
from root_pandas import read_root
import uproot

branches = [u'event', 
       u'rechit_layer','rechit_module', u'rechit_chip', u'rechit_channel', u'rechit_x', u'rechit_y', u'rechit_z',
       u'rechit_energy', u'rechit_amplitudeHigh', u'rechit_amplitudeLow', u'rechit_Tot', 'rechit_toaRise',
       'rechit_TS3High','rechit_TS3Low',  'rechit_TS2High','rechit_TS2Low']

rh_branches = [branch for branch in branches if "rechit" in branch]

%%time
df_root_pandas = read_root("ntuple_426.root",key='rechitntupler/hits',
                           columns=branches, flatten = rh_branches)

%%time
df_uproot = uproot.open("ntuple_426.root")["rechitntupler/hits"].pandas.df(
    branches=branches, flatten=True)
```

Shout-out to @artlbv who originally recognized the slowness and made the comparison with root_pandas!