### PR TITLE
Read Double32_t values with truncated mantissa

### DIFF
--- a/uproot/interp/numerical.py
+++ b/uproot/interp/numerical.py
@@ -287,13 +287,17 @@ class asdouble32(_asnumeric):
         return quotient
 
     def fromroot(self, data, byteoffsets, local_entrystart, local_entrystop):
+        # Make sure the shape of the interpreted data conforms to the shape of the input data
+        def reshape(array):
+            product = int(self.awkward.numpy.prod(self.fromdims))
+            quotient, remainder = divmod(len(array), product)
+            assert remainder == 0, "{0} % {1} == {2} != 0".format(len(array), product, len(array) % product)
+            array = array.reshape((quotient,) + self.fromdims)
+            return array
+
         if self.truncated:
             array = data.view(dtype={'exponent': ('>u1',0), 'mantissa': ('>u2',1)})
-            if self.fromdims != ():
-                product = int(self.awkward.numpy.prod(self.fromdims))
-                quotient, remainder = divmod(len(array), product)
-                assert remainder == 0, "{0} % {1} == {2} != 0".format(len(array), product, len(array) % product)
-                array = array.reshape((quotient,) + self.fromdims)
+            array = reshape(array) if self.fromdims != () else array
 
             # We have to make copies to work with contiguous arrays
             unpacked = array['exponent'].astype('int32')
@@ -308,11 +312,7 @@ class asdouble32(_asnumeric):
 
         else:
             array = data.view(">u4")
-            if self.fromdims != ():
-                product = int(self.awkward.numpy.prod(self.fromdims))
-                quotient, remainder = divmod(len(array), product)
-                assert remainder == 0, "{0} % {1} == {2} != 0".format(len(array), product, len(array) % product)
-                array = array.reshape((quotient,) + self.fromdims)
+            array = reshape(array) if self.fromdims != () else array
 
             array = array[local_entrystart:local_entrystop].astype(self.todtype)
             self.awkward.numpy.multiply(array, float(self.high - self.low) / (1 << self.numbits), out=array)


### PR DESCRIPTION
This commit implements unpacking of the Double32_t format in which the exponent
and mantissa of the original double value (cast to single precision) are
streamed as 8-bit and 16-bit integers respectively.

Depending on the specification provided by the user the ROOT's Double32_t
values can be packed and streamed to a ROOT file in other two formats. In the
first mode the original double precision values are simply cast to a single
precision and streamed without further manipulation. In the second mode the
double values (again, cast to float and scaled to a given range) are saved as
32-bit integers. These two modes are already taken care of by the
`uproot.interp.auto.interpret()` function and the
`uproot.interp.numerical.asdouble32` interpretation.

For details on Double32_t streaming modes see
https://root.cern/doc/v616/classTBufferFile.html#a44c2adb6fb1194ec999b84aed259e5bc