### PR TITLE
Add connection period and duration limits to Binder build API curl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,4 +96,4 @@ jobs:
     install: skip
     script:
     # Use Binder build API to trigger repo2docker to build image
-    - curl https://mybinder.org/build/gh/scikit-hep/uproot/master
+    - bash binder/trigger_binder.sh https://mybinder.org/build/gh/scikit-hep/uproot/"${TRAVIS_BRANCH}"

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ uproot
 .. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.1173083.svg
    :target: https://doi.org/10.5281/zenodo.1173083
 
-.. image:: https://mybinder.org/badge.svg
+.. image:: https://mybinder.org/badge_logo.svg
    :target: https://mybinder.org/v2/gh/scikit-hep/uproot/master?filepath=binder%2Ftutorial.ipynb
 
 .. inclusion-marker-1-do-not-remove

--- a/binder/trigger_binder.sh
+++ b/binder/trigger_binder.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+function trigger_binder() {
+    local URL="${1}"
+
+    curl --connect-timeout 10 --max-time 30 "${URL}"
+    curl_return=$?
+
+    # Return code 28 is when the --max-time is reached
+    if [ "${curl_return}" -eq 0 ] || [ "${curl_return}" -eq 28 ]; then
+        if [[ "${curl_return}" -eq 28 ]]; then
+            printf "\nBinder build started.\nCheck back soon.\n"
+        fi
+    else
+        return "${curl_return}"
+    fi
+
+    return 0
+}
+
+function main() {
+    # 1: the Binder build API URL to curl
+    trigger_binder $1
+}
+
+main "$@" || exit 1


### PR DESCRIPTION
The use of `connect-timeout` is to make sure that the curl doesn't try to repeatedly hit the URL if the connection is down or unresponsive for an unreasonably long time. The use of max-time is so that for longer builds the curl doesn't try to follow them for the duration. It just hits the API endpoint and then exits at most 60 seconds later. Additionally the trigger function accepts `--max-time` exit return code, `28`, as valid and then return success.

An [example of this working on a test branch can be found on Travis CI Build #1487](https://travis-ci.org/scikit-hep/uproot/jobs/495674517).

Also [update the launch Binder badge](https://discourse.jupyter.org/t/help-us-choose-an-updated-launch-binder-badge/100).