### PR TITLE
Preload chunked data sources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
   - conda config --add channels conda-forge;
   - conda config --set always_yes yes --set changeps1 no
   - if [ "${PYVER}" = "2.7" ] || [ "${PYVER}" = "3.6" ] || [ "${PYVER}" = "3.7" ]; then
-      conda create -q -n testenv python=${PYVER} root;   # xrootd (to enable XRootD test in issue240)
+      conda create -q -n testenv python=${PYVER} root;
     elif [[ "${PYVER}" = pypy* ]]; then
       conda create -q -n testenv ${PYVER};
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ install:
   - python -c 'import awkward; print(awkward.__version__)'
   - pip install "uproot-methods>=0.3.0"
   - python -c 'import uproot_methods; print(uproot_methods.__version__)'
+  - pip install cachetools
   - pip install "pytest>=3.9" pytest-runner
   - pip install lz4 requests
   - if [[ $TRAVIS_PYTHON_VERSION = "2.7" ]] ; then pip install backports.lzma ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
   - conda config --add channels conda-forge;
   - conda config --set always_yes yes --set changeps1 no
   - if [ "${PYVER}" = "2.7" ] || [ "${PYVER}" = "3.6" ] || [ "${PYVER}" = "3.7" ]; then
-      conda create -q -n testenv python=${PYVER} root xrootd;
+      conda create -q -n testenv python=${PYVER} root;   # xrootd (to enable XRootD test in issue240)
     elif [[ "${PYVER}" = pypy* ]]; then
       conda create -q -n testenv ${PYVER};
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
   - conda config --add channels conda-forge;
   - conda config --set always_yes yes --set changeps1 no
   - if [ "${PYVER}" = "2.7" ] || [ "${PYVER}" = "3.6" ] || [ "${PYVER}" = "3.7" ]; then
-      conda create -q -n testenv python=${PYVER} root;
+      conda create -q -n testenv python=${PYVER} root xrootd;
     elif [[ "${PYVER}" = pypy* ]]; then
       conda create -q -n testenv ${PYVER};
     else
@@ -65,7 +65,7 @@ addons:
       - python-setuptools
 
 script:
-  python setup.py pytest
+  pytest -v tests
 
 notifications:
   slack: scikit-hep:b6cgBXwccPoaCNLn5VKFJFVy

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,7 @@ install:
   - python -c 'import awkward; print(awkward.__version__)'
   - pip install "uproot-methods>=0.3.0"
   - python -c 'import uproot_methods; print(uproot_methods.__version__)'
-  - pip install cachetools
-  - pip install "pytest>=3.9" pytest-runner
+  - pip install cachetools pkgconfig lz4 mock requests "pytest>=3.9" pytest-runner
   - pip install lz4 requests
   - if [[ $TRAVIS_PYTHON_VERSION = "2.7" ]] ; then pip install backports.lzma ; fi
   - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]] ; then pip install pandas ; fi

--- a/setup.py
+++ b/setup.py
@@ -96,8 +96,6 @@ Reference documentation
 """
     return before + middle + after
 
-dependencies = ["numpy>=1.13.1", "awkward>=0.8.0", "uproot-methods>=0.4.0", "cachetools"]
-
 setup(name = "uproot",
       version = get_version(),
       packages = find_packages(exclude = ["tests"]),
@@ -112,9 +110,9 @@ setup(name = "uproot",
       download_url = "https://github.com/scikit-hep/uproot/releases",
       license = "BSD 3-clause",
       test_suite = "tests",
-      install_requires = dependencies,
+      install_requires = ["numpy>=1.13.1", "awkward>=0.8.0", "uproot-methods>=0.4.0", "cachetools"],
       setup_requires = ["pytest-runner"],
-      tests_require = dependencies + ["pytest>=3.9", "pkgconfig", "lz4", 'backports.lzma;python_version<"3.3"', "mock", "requests"],
+      tests_require = ["pytest>=3.9", "pkgconfig", "lz4", 'backports.lzma;python_version<"3.3"', "mock", "requests"],
       classifiers = [
           "Development Status :: 5 - Production/Stable",
           "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,8 @@ Reference documentation
 """
     return before + middle + after
 
+dependencies = ["numpy>=1.13.1", "awkward>=0.8.0", "uproot-methods>=0.4.0", "cachetools"]
+
 setup(name = "uproot",
       version = get_version(),
       packages = find_packages(exclude = ["tests"]),
@@ -110,9 +112,9 @@ setup(name = "uproot",
       download_url = "https://github.com/scikit-hep/uproot/releases",
       license = "BSD 3-clause",
       test_suite = "tests",
-      install_requires = ["numpy>=1.13.1", "awkward>=0.8.0", "uproot-methods>=0.4.0", "cachetools"],
+      install_requires = dependencies,
       setup_requires = ["pytest-runner"],
-      tests_require = ["pytest>=3.9", "pkgconfig", "lz4", 'backports.lzma;python_version<"3.3"', "mock", "requests"],
+      tests_require = dependencies + ["pytest>=3.9", "pkgconfig", "lz4", 'backports.lzma;python_version<"3.3"', "mock", "requests"],
       classifiers = [
           "Development Status :: 5 - Production/Stable",
           "Intended Audience :: Developers",

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -32,6 +32,7 @@ import unittest
 
 from collections import namedtuple
 
+import pytest
 import numpy
 
 import uproot
@@ -201,3 +202,12 @@ class Test(unittest.TestCase):
         else:
             t = uproot.open("tests/samples/issue232.root")["fTreeV0"]
             t.pandas.df(["V0Hyper.fNsigmaHe3Pos", "V0Hyper.fDcaPos2PrimaryVertex"], flatten=True)
+
+    def test_issue240(self):
+        try:
+            import pyxrootd
+        except ImportError:
+            pytest.skip("unable to import pyxrootd")
+        else:
+            t = uproot.open("root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root")["Events"]
+            assert (abs(t.array("nMuon")) < 50).all()

--- a/uproot/source/chunked.py
+++ b/uproot/source/chunked.py
@@ -37,14 +37,25 @@ class ChunkedSource(uproot.source.source.Source):
     # makes __doc__ attribute mutable before Python 3.3
     __metaclass__ = type.__new__(type, "type", (uproot.source.source.Source.__metaclass__,), {})
 
-    def __init__(self, path, chunkbytes, limitbytes):
+    def __init__(self, path, chunkbytes, limitbytes, numthreads):
         self.path = path
         self._chunkbytes = chunkbytes
+        self._limitbytes = limitbytes
         if limitbytes is None:
             self.cache = {}
         else:
             self.cache = uproot.cache.ThreadSafeArrayCache(limitbytes)
         self._source = None
+        if numthreads is not None and numthreads > 1:
+            try:
+                import concurrent.futures
+            except ImportError:
+                raise ImportError("Install futures package (for numthreads > 1) with:\n    pip install futures\nor\n    conda install -c conda-forge futures")
+            self._executor = concurrent.futures.ThreadPoolExecutor()
+            self._futures = {}
+        else:
+            self._executor = None
+            self._futures = None
 
     def parent(self):
         return self
@@ -59,7 +70,29 @@ class ChunkedSource(uproot.source.source.Source):
         raise NotImplementedError
 
     def dismiss(self):
-        pass
+        if self._futures is not None:
+            for future in self._futures.values():
+                future.cancel()
+            self._futures = {}
+
+    def _preload(self, chunkindex):
+        try:
+            chunk = self.cache[chunkindex]
+        except KeyError:
+            return self._read(chunkindex)
+        else:
+            return chunk
+
+    def preload(self, starts):
+        self._open()
+        limitnum = self._limitbytes // self._chunkbytes
+        if self._executor is not None:
+            for start in starts:
+                if len(self._futures) > limitnum:
+                    break
+                chunkindex = start // self._chunkbytes
+                if chunkindex not in self._futures:
+                    self._futures[chunkindex] = self._executor.submit(self._preload, chunkindex)
 
     def data(self, start, stop, dtype=None):
         if dtype is None:
@@ -80,11 +113,18 @@ class ChunkedSource(uproot.source.source.Source):
         out = numpy.empty((stop - start) // thedtype.itemsize, dtype=thedtype)
 
         for chunkindex in range(chunkstart, chunkstop):
-            try:
-                chunk = self.cache[chunkindex]
-            except KeyError:
-                self._open()
-                chunk = self.cache[chunkindex] = self._read(chunkindex)
+            chunk = None
+            if self._futures is not None:
+                future = self._futures.pop(chunkindex, None)
+                if future is not None:
+                    chunk = self.cache[chunkindex] = future.result()
+
+            if chunk is None:
+                try:
+                    chunk = self.cache[chunkindex]
+                except KeyError:
+                    self._open()
+                    chunk = self.cache[chunkindex] = self._read(chunkindex)
 
             cstart = 0
             cstop = self._chunkbytes

--- a/uproot/source/chunked.py
+++ b/uproot/source/chunked.py
@@ -72,7 +72,7 @@ class ChunkedSource(uproot.source.source.Source):
                 import concurrent.futures
             except ImportError:
                 raise ImportError("Install futures package (for threads > 1) with:\n    pip install futures\nor\n    conda install -c conda-forge futures")
-            self._executor = concurrent.futures.ThreadPoolExecutor()
+            self._executor = concurrent.futures.ThreadPoolExecutor(threads)
             self._futures = {}
         else:
             self._executor = None

--- a/uproot/source/chunked.py
+++ b/uproot/source/chunked.py
@@ -120,7 +120,9 @@ class ChunkedSource(uproot.source.source.Source):
             if self._futures is not None:
                 future = self._futures.pop(chunkindex, None)
                 if future is not None:
-                    chunk = self.cache[chunkindex] = future.result()
+                    chunk = future.result()
+                    if chunk is not None:
+                        self.cache[chunkindex] = chunk
 
             if chunk is None:
                 try:

--- a/uproot/source/chunked.py
+++ b/uproot/source/chunked.py
@@ -37,7 +37,7 @@ class ChunkedSource(uproot.source.source.Source):
     # makes __doc__ attribute mutable before Python 3.3
     __metaclass__ = type.__new__(type, "type", (uproot.source.source.Source.__metaclass__,), {})
 
-    def __init__(self, path, chunkbytes, limitbytes, threads):
+    def __init__(self, path, chunkbytes, limitbytes, parallel):
         self.path = path
         self._chunkbytes = chunkbytes
         self._limitbytes = limitbytes
@@ -46,7 +46,7 @@ class ChunkedSource(uproot.source.source.Source):
         else:
             self.cache = uproot.cache.ThreadSafeArrayCache(limitbytes)
         self._source = None
-        self._setup_futures(threads)
+        self._setup_futures(parallel)
 
     def parent(self):
         return self
@@ -66,13 +66,13 @@ class ChunkedSource(uproot.source.source.Source):
                 future.cancel()
             self._futures = {}
 
-    def _setup_futures(self, threads):
-        if threads is not None and threads > 1:
+    def _setup_futures(self, parallel):
+        if parallel is not None and parallel > 1:
             try:
                 import concurrent.futures
             except ImportError:
-                raise ImportError("Install futures package (for threads > 1) with:\n    pip install futures\nor\n    conda install -c conda-forge futures")
-            self._executor = concurrent.futures.ThreadPoolExecutor(threads)
+                raise ImportError("Install futures package (for parallel > 1) with:\n    pip install futures\nor\n    conda install -c conda-forge futures")
+            self._executor = concurrent.futures.ThreadPoolExecutor(parallel)
             self._futures = {}
         else:
             self._executor = None

--- a/uproot/source/http.py
+++ b/uproot/source/http.py
@@ -46,7 +46,7 @@ class HTTPSource(uproot.source.chunked.ChunkedSource):
         self._size = None
         self.auth = auth
 
-    defaults = {"chunkbytes": 32*1024, "limitbytes": 32*1024**2, "threads": 4*multiprocessing.cpu_count() if sys.version_info[0] > 2 else 1}
+    defaults = {"chunkbytes": 32*1024, "limitbytes": 32*1024**2, "threads": 8*multiprocessing.cpu_count() if sys.version_info[0] > 2 else 1}
 
     def _open(self):
         try:

--- a/uproot/source/http.py
+++ b/uproot/source/http.py
@@ -30,6 +30,8 @@
 
 import os.path
 import re
+import multiprocessing
+import sys
 
 import numpy
 
@@ -44,7 +46,7 @@ class HTTPSource(uproot.source.chunked.ChunkedSource):
         self._size = None
         self.auth = auth
 
-    defaults = {"chunkbytes": 16*1024, "limitbytes": 16*1024**2}
+    defaults = {"chunkbytes": 32*1024, "limitbytes": 32*1024**2, "numthreads": 4*multiprocessing.cpu_count() if sys.version_info[0] > 2 else 1}
 
     def _open(self):
         try:

--- a/uproot/source/http.py
+++ b/uproot/source/http.py
@@ -46,7 +46,7 @@ class HTTPSource(uproot.source.chunked.ChunkedSource):
         self._size = None
         self.auth = auth
 
-    defaults = {"chunkbytes": 32*1024, "limitbytes": 32*1024**2, "threads": 8*multiprocessing.cpu_count() if sys.version_info[0] > 2 else 1}
+    defaults = {"chunkbytes": 32*1024, "limitbytes": 32*1024**2, "parallel": 8*multiprocessing.cpu_count() if sys.version_info[0] > 2 else 1}
 
     def _open(self):
         try:

--- a/uproot/source/http.py
+++ b/uproot/source/http.py
@@ -46,7 +46,7 @@ class HTTPSource(uproot.source.chunked.ChunkedSource):
         self._size = None
         self.auth = auth
 
-    defaults = {"chunkbytes": 32*1024, "limitbytes": 32*1024**2, "numthreads": 4*multiprocessing.cpu_count() if sys.version_info[0] > 2 else 1}
+    defaults = {"chunkbytes": 32*1024, "limitbytes": 32*1024**2, "threads": 4*multiprocessing.cpu_count() if sys.version_info[0] > 2 else 1}
 
     def _open(self):
         try:

--- a/uproot/source/source.py
+++ b/uproot/source/source.py
@@ -53,6 +53,9 @@ class Source(object):
     def close(self):
         self.dismiss()
 
+    def preload(self, starts):
+        pass
+
     def data(self, start, stop, dtype=None):
         # assert start >= 0
         # assert stop >= 0

--- a/uproot/source/xrootd.py
+++ b/uproot/source/xrootd.py
@@ -104,7 +104,7 @@ class XRootDSource(uproot.source.chunked.ChunkedSource):
 
         def result(self):
             if self.hold.wait(self.timeout):
-                return out
+                return self.out
 
     def preload(self, starts):
         if self._threads:

--- a/uproot/source/xrootd.py
+++ b/uproot/source/xrootd.py
@@ -115,7 +115,9 @@ class XRootDSource(uproot.source.chunked.ChunkedSource):
                 if len(self._futures) > limitnum:
                     break
                 chunkindex = start // self._chunkbytes
-                if self.cache[chunkindex] is None:
+                try:
+                    self.cache[chunkindex]
+                except KeyError:
                     self.futures[chunkindex] = self._source.read(chunkindex * self._chunkbytes, self._chunkbytes, timeout=timeout, callback=self._preload(timeout))
 
     def __del__(self):

--- a/uproot/source/xrootd.py
+++ b/uproot/source/xrootd.py
@@ -28,6 +28,9 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import multiprocessing
+import sys
+
 import numpy
 
 import uproot.source.chunked
@@ -41,7 +44,7 @@ class XRootDSource(uproot.source.chunked.ChunkedSource):
         self.timeout = timeout
         super(XRootDSource, self).__init__(path, *args, **kwds)
 
-    defaults = {"timeout": None, "chunkbytes": 16*1024, "limitbytes": 16*1024**2}
+    defaults = {"timeout": None, "chunkbytes": 32*1024, "limitbytes": 32*1024**2, "numthreads": 4*multiprocessing.cpu_count() if sys.version_info[0] > 2 else 1}
 
     def _open(self):
         try:

--- a/uproot/source/xrootd.py
+++ b/uproot/source/xrootd.py
@@ -104,15 +104,16 @@ class XRootDSource(uproot.source.chunked.ChunkedSource):
                 return out
 
     def preload(self, starts):
-        self._open()
-        limitnum = self._limitbytes // self._chunkbytes
-        timeout = 0 if self.timeout is None else self.timeout
-        for start in starts:
-            if len(self._futures) > limitnum:
-                break
-            chunkindex = start // self._chunkbytes
-            if self.cache[chunkindex] is None:
-                self.futures[chunkindex] = self._source.read(chunkindex * self._chunkbytes, self._chunkbytes, timeout=timeout, callback=self._preload(timeout))
+        if self._threads:
+            self._open()
+            limitnum = self._limitbytes // self._chunkbytes
+            timeout = 0 if self.timeout is None else self.timeout
+            for start in starts:
+                if len(self._futures) > limitnum:
+                    break
+                chunkindex = start // self._chunkbytes
+                if self.cache[chunkindex] is None:
+                    self.futures[chunkindex] = self._source.read(chunkindex * self._chunkbytes, self._chunkbytes, timeout=timeout, callback=self._preload(timeout))
 
     def __del__(self):
         if self._source is not None:

--- a/uproot/source/xrootd.py
+++ b/uproot/source/xrootd.py
@@ -118,7 +118,10 @@ class XRootDSource(uproot.source.chunked.ChunkedSource):
                 try:
                     self.cache[chunkindex]
                 except KeyError:
-                    self._futures[chunkindex] = self._source.read(chunkindex * self._chunkbytes, self._chunkbytes, timeout=timeout, callback=self._preload(timeout))
+                    callback = self._preload(timeout)
+                    status = self._source.read(chunkindex * self._chunkbytes, self._chunkbytes, timeout=timeout, callback=callback)
+                    if status["ok"]:
+                        self._futures[chunkindex] = callback
 
     def __del__(self):
         if self._source is not None:

--- a/uproot/source/xrootd.py
+++ b/uproot/source/xrootd.py
@@ -74,6 +74,9 @@ class XRootDSource(uproot.source.chunked.ChunkedSource):
         out._source = None             # XRootD connections are *not shared* among threads
         out._size = self._size
         out.timeout = self.timeout
+        out._threads = self._threads
+        out._executor = None
+        out._futures = {}
         return out
 
     def _read(self, chunkindex):

--- a/uproot/source/xrootd.py
+++ b/uproot/source/xrootd.py
@@ -118,7 +118,7 @@ class XRootDSource(uproot.source.chunked.ChunkedSource):
                 try:
                     self.cache[chunkindex]
                 except KeyError:
-                    self.futures[chunkindex] = self._source.read(chunkindex * self._chunkbytes, self._chunkbytes, timeout=timeout, callback=self._preload(timeout))
+                    self._futures[chunkindex] = self._source.read(chunkindex * self._chunkbytes, self._chunkbytes, timeout=timeout, callback=self._preload(timeout))
 
     def __del__(self):
         if self._source is not None:

--- a/uproot/tree.py
+++ b/uproot/tree.py
@@ -1271,6 +1271,9 @@ class TBranchMethods(object):
         entrystart, entrystop = self._normalize_entrystartstop(entrystart, entrystop)
         basketstart, basketstop = self._basketstartstop(entrystart, entrystop)
 
+        if self._source.parent() is not None:
+            self._source.parent().preload([self._fBasketSeek[i] for i in range(basketstart, basketstop)])
+
         if cache is not None:
             cachekey = self._cachekey(interpretation, entrystart, entrystop)
             out = cache.get(cachekey, None)

--- a/uproot/version.py
+++ b/uproot/version.py
@@ -30,7 +30,7 @@
 
 import re
 
-__version__ = "3.4.9"
+__version__ = "3.4.10"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
This addresses issue #240, though it only implements step 2 in a generic way that applies to both XRootD and HTTP. It has only been tested on HTTP, and there might be a more specific function to call to do background-loading in XRootD.

The `test_tree.Test.test_hist_in_tree` function was particularly slow using HTTP: 25 seconds. Preloading reduces this time to 5 seconds.