### PR TITLE
Let flat pandas dataframes have the same index format as jagged dfs

### DIFF
--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -665,3 +665,11 @@ class Test(unittest.TestCase):
             tree = uproot.open("tests/samples/HZZ-objects.root")["events"]
             tree.pandas.df("muonp4")
             tree.pandas.df("muonp4", flatten=False)
+            df = tree.pandas.df("eventweight", entrystart=100, entrystop=200)
+            index = df.index.tolist()
+            assert min(index) == 100
+            assert max(index) == 199
+            df = tree.pandas.df("muonp4", entrystart=100, entrystop=200)
+            index = df.index.get_level_values("entry").tolist()
+            assert min(index) == 100
+            assert max(index) == 199

--- a/uproot/_connect/to_pandas.py
+++ b/uproot/_connect/to_pandas.py
@@ -60,7 +60,7 @@ def default_flatname(branchname, fieldname, index):
         out += "[" + "][".join(str(x) for x in index) + "]"
     return out
 
-def futures2df(futures, outputtype, entrystart, entrystop, flatten, flatname, awkward):
+def futures2df(futures, outputtype, entrystart, entrystop, flatten, flatname, awkward, indexbyentry=True):
     import pandas
 
     if flatname is None:
@@ -106,7 +106,12 @@ def futures2df(futures, outputtype, entrystart, entrystop, flatten, flatname, aw
                 columns.append(fn)
                 data[fn] = list(array)     # must be serialized as a Python list for Pandas to accept it
 
-        return outputtype(columns=columns, data=data)
+        index = None
+        if indexbyentry and entrystart:
+            if not entrystop:
+                entrystop = entrystop + len(columns[0])
+            index = pandas.RangeIndex(entrystart, entrystop, name="entry")
+        return outputtype(columns=columns, data=data, index=index)
 
     else:
         starts, stops = None, None

--- a/uproot/_connect/to_pandas.py
+++ b/uproot/_connect/to_pandas.py
@@ -60,7 +60,7 @@ def default_flatname(branchname, fieldname, index):
         out += "[" + "][".join(str(x) for x in index) + "]"
     return out
 
-def futures2df(futures, outputtype, entrystart, entrystop, flatten, flatname, awkward, indexbyentry=True):
+def futures2df(futures, outputtype, entrystart, entrystop, flatten, flatname, awkward):
     import pandas
 
     if flatname is None:
@@ -106,11 +106,7 @@ def futures2df(futures, outputtype, entrystart, entrystop, flatten, flatname, aw
                 columns.append(fn)
                 data[fn] = list(array)     # must be serialized as a Python list for Pandas to accept it
 
-        index = None
-        if indexbyentry and entrystart:
-            if not entrystop:
-                entrystop = entrystop + len(columns[0])
-            index = pandas.RangeIndex(entrystart, entrystop, name="entry")
+        index = pandas.RangeIndex(entrystart, entrystop, name="entry")
         return outputtype(columns=columns, data=data, index=index)
 
     else:

--- a/uproot/version.py
+++ b/uproot/version.py
@@ -30,7 +30,7 @@
 
 import re
 
-__version__ = "3.4.13"
+__version__ = "3.4.14"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
Adds an argument to futures2df function to respect entrystart in output dataframe.  Although it's an optional argument for futures2df, I'm not actually passing it through from `pandas.df` or `arrays` at this point, so it's essentially always enabled (since that's the default parameter).   I can set this up, but I was unsure if we want to add this argument to `arrays` since it's only meaningful if the outputtype is a pandas dataframe.

Addresses issue #256.

(Apologies, I accidentally pushed this as a new branch to the uproot repo, rather than my own fork -- happy to close, delete branch, and re-open from my fork.)