### PR TITLE
Fix iteration over DataFrames and provide more interfaces

### DIFF
--- a/uproot/__init__.py
+++ b/uproot/__init__.py
@@ -143,10 +143,6 @@ from uproot.write.TFile import TFileCreate as create
 from uproot.write.TFile import TFileRecreate as recreate
 from uproot.write.TFile import TFileUpdate as update
 
-# import uproot._connect.to_pandas
-# pandas = uproot._connect.to_pandas.Pandas
-# del uproot._connect.to_pandas
-
 from uproot.source.memmap import MemmapSource
 from uproot.source.file import FileSource
 from uproot.source.xrootd import XRootDSource
@@ -168,6 +164,23 @@ from uproot.interp.objects import STLMap
 from uproot.interp.objects import STLString
 asdebug = asjagged(asdtype("u1"))
 
+from uproot.source.memmap import MemmapSource
+from uproot.source.xrootd import XRootDSource
+from uproot.source.http import HTTPSource
+def iterate(path, treepath, branches=None, entrysteps=None, namedecode="utf-8", reportpath=False, reportfile=False, flatten=True, flatname=None, awkwardlib=None, cache=None, basketcache=None, keycache=None, executor=None, blocking=True, localsource=MemmapSource.defaults, xrootdsource=XRootDSource.defaults, httpsource=HTTPSource.defaults, **options):
+    import pandas
+    import uproot.tree
+    return uproot.tree.iterate(path, treepath, branches=branches, entrysteps=entrysteps, outputtype=pandas.DataFrame, namedecode=namedecode, reportpath=reportpath, reportfile=reportfile, reportentries=False, flatten=flatten, flatname=flatname, awkwardlib=awkwardlib, cache=cache, basketcache=basketcache, keycache=keycache, executor=executor, blocking=blocking, localsource=localsource, xrootdsource=xrootdsource, httpsource=httpsource, **options)
+
+from types import ModuleType
+pandas = ModuleType("uproot.pandas")
+pandas.iterate = iterate
+del ModuleType
+del iterate
+del MemmapSource
+del XRootDSource
+del HTTPSource
+
 # put help strings on everything (they're long, too disruptive to intersperse
 # in the code, and are built programmatically to avoid duplication; Python's
 # inline docstring method doesn't accept non-literals)
@@ -176,7 +189,6 @@ import uproot._help
 # convenient access to the version number
 from uproot.version import __version__
 
-# don't expose uproot.uproot; it's ugly
 del uproot
 
-__all__ = ["open", "xrootd", "http", "iterate", "numentries", "lazyarray", "lazyarrays", "daskarray", "daskarrays", "daskframe", "create", "recreate", "update", "MemmapSource", "FileSource", "XRootDSource", "HTTPSource", "interpret", "asdtype", "asarray", "asdouble32", "asstlbitset", "asjagged", "astable", "asobj", "asgenobj", "asstring", "asdebug", "SimpleArray", "STLVector", "STLMap", "STLString", "__version__"]
+__all__ = ["open", "xrootd", "http", "iterate", "numentries", "lazyarray", "lazyarrays", "daskarray", "daskarrays", "daskframe", "create", "recreate", "update", "MemmapSource", "FileSource", "XRootDSource", "HTTPSource", "interpret", "asdtype", "asarray", "asdouble32", "asstlbitset", "asjagged", "astable", "asobj", "asgenobj", "asstring", "asdebug", "SimpleArray", "STLVector", "STLMap", "STLString", "pandas", "__version__"]

--- a/uproot/__init__.py
+++ b/uproot/__init__.py
@@ -164,22 +164,7 @@ from uproot.interp.objects import STLMap
 from uproot.interp.objects import STLString
 asdebug = asjagged(asdtype("u1"))
 
-from uproot.source.memmap import MemmapSource
-from uproot.source.xrootd import XRootDSource
-from uproot.source.http import HTTPSource
-def iterate(path, treepath, branches=None, entrysteps=None, namedecode="utf-8", reportpath=False, reportfile=False, flatten=True, flatname=None, awkwardlib=None, cache=None, basketcache=None, keycache=None, executor=None, blocking=True, localsource=MemmapSource.defaults, xrootdsource=XRootDSource.defaults, httpsource=HTTPSource.defaults, **options):
-    import pandas
-    import uproot.tree
-    return uproot.tree.iterate(path, treepath, branches=branches, entrysteps=entrysteps, outputtype=pandas.DataFrame, namedecode=namedecode, reportpath=reportpath, reportfile=reportfile, reportentries=False, flatten=flatten, flatname=flatname, awkwardlib=awkwardlib, cache=cache, basketcache=basketcache, keycache=keycache, executor=executor, blocking=blocking, localsource=localsource, xrootdsource=xrootdsource, httpsource=httpsource, **options)
-
-from types import ModuleType
-pandas = ModuleType("uproot.pandas")
-pandas.iterate = iterate
-del ModuleType
-del iterate
-del MemmapSource
-del XRootDSource
-del HTTPSource
+from uproot import pandas
 
 # put help strings on everything (they're long, too disruptive to intersperse
 # in the code, and are built programmatically to avoid duplication; Python's
@@ -189,6 +174,7 @@ import uproot._help
 # convenient access to the version number
 from uproot.version import __version__
 
+# don't expose uproot.uproot; it's ugly
 del uproot
 
 __all__ = ["open", "xrootd", "http", "iterate", "numentries", "lazyarray", "lazyarrays", "daskarray", "daskarrays", "daskframe", "create", "recreate", "update", "MemmapSource", "FileSource", "XRootDSource", "HTTPSource", "interpret", "asdtype", "asarray", "asdouble32", "asstlbitset", "asjagged", "astable", "asobj", "asgenobj", "asstring", "asdebug", "SimpleArray", "STLVector", "STLMap", "STLString", "pandas", "__version__"]

--- a/uproot/__init__.py
+++ b/uproot/__init__.py
@@ -143,6 +143,10 @@ from uproot.write.TFile import TFileCreate as create
 from uproot.write.TFile import TFileRecreate as recreate
 from uproot.write.TFile import TFileUpdate as update
 
+# import uproot._connect.to_pandas
+# pandas = uproot._connect.to_pandas.Pandas
+# del uproot._connect.to_pandas
+
 from uproot.source.memmap import MemmapSource
 from uproot.source.file import FileSource
 from uproot.source.xrootd import XRootDSource

--- a/uproot/_connect/to_pandas.py
+++ b/uproot/_connect/to_pandas.py
@@ -47,12 +47,6 @@ from uproot.source.memmap import MemmapSource
 from uproot.source.xrootd import XRootDSource
 from uproot.source.http import HTTPSource
 
-class Pandas(object):
-    @staticmethod
-    def iterate(path, treepath, branches=None, entrysteps=None, namedecode="utf-8", reportpath=False, reportfile=False, flatten=True, flatname=None, awkwardlib=None, cache=None, basketcache=None, keycache=None, executor=None, blocking=True, localsource=MemmapSource.defaults, xrootdsource=XRootDSource.defaults, httpsource=HTTPSource.defaults, **options):
-        import pandas
-        return uproot.tree.iterate(path, treepath, branches=branches, entrysteps=entrysteps, outputtype=pandas.DataFrame, namedecode=namedecode, reportpath=reportpath, reportfile=reportfile, reportentries=False, flatten=flatten, flatname=flatname, awkwardlib=awkwardlib, cache=cache, basketcache=basketcache, keycache=keycache, executor=executor, blocking=blocking, localsource=localsource, xrootdsource=xrootdsource, httpsource=httpsource, **options)
-
 class TTreeMethods_pandas(object):
     def __init__(self, tree):
         self._tree = tree
@@ -146,7 +140,7 @@ def futures2df(futures, outputtype, entrystart, entrystop, flatten, flatname, aw
                     interpretation = interpretation.content
 
                 # justifies the assumption that array.content == array.flatten() and array.stops.max() == array.stops[-1]
-                assert array._canuseoffset() and len(array.starts) > 0 and array.starts[0] == 0
+                assert array._canuseoffset() and (len(array.starts) == 0 or array.starts[0] == 0)
 
                 if starts is None:
                     starts = array.starts
@@ -156,7 +150,10 @@ def futures2df(futures, outputtype, entrystart, entrystop, flatten, flatname, aw
                     if starts is not array.starts and not awkward.numpy.array_equal(starts, array.starts):
                         raise ValueError("cannot use flatten=True on branches with different jagged structure, such as electrons and muons (different, variable number of each per event); either explicitly select compatible branches, such as [\"MET_*\", \"Muon_*\"] (scalar and variable per event is okay), or set flatten=False")
 
-                array = array.content
+                if len(array.starts) == 0:
+                    array = array.content[0:0]
+                else:
+                    array = array.content
                 needbroadcasts.append(False)
 
             else:

--- a/uproot/_connect/to_pandas.py
+++ b/uproot/_connect/to_pandas.py
@@ -36,19 +36,34 @@ import numpy
 
 import awkward as awkwardbase
 
+import uproot.tree
 import uproot.interp.numerical
 from uproot.interp.jagged import asjagged
 from uproot.interp.numerical import asdtype
 from uproot.interp.objects import asobj
 from uproot.interp.objects import astable
 
+from uproot.source.memmap import MemmapSource
+from uproot.source.xrootd import XRootDSource
+from uproot.source.http import HTTPSource
+
+class Pandas(object):
+    @staticmethod
+    def iterate(path, treepath, branches=None, entrysteps=None, namedecode="utf-8", reportpath=False, reportfile=False, flatten=True, flatname=None, awkwardlib=None, cache=None, basketcache=None, keycache=None, executor=None, blocking=True, localsource=MemmapSource.defaults, xrootdsource=XRootDSource.defaults, httpsource=HTTPSource.defaults, **options):
+        import pandas
+        return uproot.tree.iterate(path, treepath, branches=branches, entrysteps=entrysteps, outputtype=pandas.DataFrame, namedecode=namedecode, reportpath=reportpath, reportfile=reportfile, reportentries=False, flatten=flatten, flatname=flatname, awkwardlib=awkwardlib, cache=cache, basketcache=basketcache, keycache=keycache, executor=executor, blocking=blocking, localsource=localsource, xrootdsource=xrootdsource, httpsource=httpsource, **options)
+
 class TTreeMethods_pandas(object):
     def __init__(self, tree):
         self._tree = tree
 
-    def df(self, branches=None, namedecode="utf-8", entrystart=None, entrystop=None, flatten=True, flatname=None, cache=None, basketcache=None, keycache=None, executor=None, blocking=True):
+    def df(self, branches=None, namedecode="utf-8", entrystart=None, entrystop=None, flatten=True, flatname=None, awkwardlib=None, cache=None, basketcache=None, keycache=None, executor=None, blocking=True):
         import pandas
-        return self._tree.arrays(branches=branches, outputtype=pandas.DataFrame, namedecode=namedecode, entrystart=entrystart, entrystop=entrystop, flatten=flatten, flatname=flatname, cache=cache, basketcache=basketcache, keycache=keycache, executor=executor, blocking=blocking)
+        return self._tree.arrays(branches=branches, outputtype=pandas.DataFrame, namedecode=namedecode, entrystart=entrystart, entrystop=entrystop, flatten=flatten, flatname=flatname, awkwardlib=awkwardlib, cache=cache, basketcache=basketcache, keycache=keycache, executor=executor, blocking=blocking)
+
+    def iterate(self, branches=None, entrysteps=None, namedecode="utf-8", entrystart=None, entrystop=None, flatten=True, flatname=None, awkwardlib=None, cache=None, basketcache=None, keycache=None, executor=None, blocking=True):
+        import pandas
+        return self._tree.iterate(branches=branches, entrysteps=entrysteps, outputtype=pandas.DataFrame, namedecode=namedecode, reportentries=False, entrystart=entrystart, entrystop=entrystop, flatten=flatten, flatname=flatname, awkwardlib=awkwardlib, cache=cache, basketcache=basketcache, keycache=keycache, executor=executor, blocking=blocking)
 
 def default_flatname(branchname, fieldname, index):
     out = branchname

--- a/uproot/pandas.py
+++ b/uproot/pandas.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2019, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Top-level functions for Pandas."""
+
+import uproot.tree
+from uproot.source.memmap import MemmapSource
+from uproot.source.xrootd import XRootDSource
+from uproot.source.http import HTTPSource
+
+def iterate(path, treepath, branches=None, entrysteps=None, namedecode="utf-8", reportpath=False, reportfile=False, flatten=True, flatname=None, awkwardlib=None, cache=None, basketcache=None, keycache=None, executor=None, blocking=True, localsource=MemmapSource.defaults, xrootdsource=XRootDSource.defaults, httpsource=HTTPSource.defaults, **options):
+    import pandas
+    return uproot.tree.iterate(path, treepath, branches=branches, entrysteps=entrysteps, outputtype=pandas.DataFrame, namedecode=namedecode, reportpath=reportpath, reportfile=reportfile, reportentries=False, flatten=flatten, flatname=flatname, awkwardlib=awkwardlib, cache=cache, basketcache=basketcache, keycache=keycache, executor=executor, blocking=blocking, localsource=localsource, xrootdsource=xrootdsource, httpsource=httpsource, **options)

--- a/uproot/rootio.py
+++ b/uproot/rootio.py
@@ -666,7 +666,7 @@ def _defineclasses(streamerinfos, classes):
 
         if isinstance(streamerinfo, TStreamerInfo) and pyclassname not in builtin_classes and (pyclassname not in classes or hasattr(classes[pyclassname], "_versions")):
             code = ["    @classmethod",
-                    "    def _readinto(cls, self, source, cursor, context, parent):",
+                    "    def _readinto(cls, self, source, cursor, context, parent, asclass=None):",
                     "        start, cnt, classversion = _startcheck(source, cursor)",
                     "        if cls._classversion != classversion:",
                     "            cursor.index = start",

--- a/uproot/tree.py
+++ b/uproot/tree.py
@@ -578,7 +578,9 @@ class TTreeMethods(object):
         elif ispandas:
             import uproot._connect.to_pandas
             def wrap_for_python_scope(futures, start, stop):
-                return lambda: uproot._connect.to_pandas.futures2df([(branch.name, interpretation, lambda: interpretation.finalize(future(), branch)) for branch, interpretation, future, past, cachekey in futures], outputtype, start, stop, flatten, flatname, awkward)
+                def wrap_again(branch, interpretation, future):
+                    return lambda: interpretation.finalize(future(), branch)
+                return lambda: uproot._connect.to_pandas.futures2df([(branch.name, interpretation, wrap_again(branch, interpretation, future)) for branch, interpretation, future, past, cachekey in futures], outputtype, start, stop, flatten, flatname, awkward)
 
         elif isinstance(outputtype, type) and issubclass(outputtype, dict):
             def wrap_for_python_scope(futures, start, stop):

--- a/uproot/version.py
+++ b/uproot/version.py
@@ -30,7 +30,7 @@
 
 import re
 
-__version__ = "3.4.15"
+__version__ = "3.4.16"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
This PR fixes #263 and provides new methods and functions:

   * `tree.pandas.iterate` is like `tree.pandas.df` in that it sets some Pandas-friendly defaults, but on `tree.iterate`, rather than `tree.arrays`.
   * `uproot.pandas.iterate` sets those Pandas-friendly defaults on `uproot.iterate`.

Various bugs were fixed. For instance, `tree.iterate` really wasn't Pandas-ready: it had fallen considerably behind `tree.arrays`, but fortunately most of the Pandas-specific stuff is in a function call now, so no code duplication was needed to get `tree.iterate` up to speed and now it will inherit any future updates.

Also, `globalentrystart` setting in `uproot.iterate` was broken for Pandas DataFrames, both for `MultiIndex` and for `RangeIndex`. The original code seemed to be expecting `Int64Index` for some reason.

All in all, the combination of iterate + Pandas was just out of date with respect to the changes that have been more fully tested on arrays + Pandas.