### PR TITLE
Make XRootDSource fork-safe

### DIFF
--- a/uproot/source/xrootd.py
+++ b/uproot/source/xrootd.py
@@ -2,6 +2,7 @@
 
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot/blob/master/LICENSE
 
+import os
 import threading
 
 import numpy
@@ -21,9 +22,7 @@ class XRootDSource(uproot.source.chunked.ChunkedSource):
 
     def _open(self):
         try:
-            import os
-            # To make uproot + xrootd + multiprocessing work
-            os.environ['XRD_RUNFORKHANDLER'] = '1'
+            os.environ["XRD_RUNFORKHANDLER"] = "1"   # To make uproot + xrootd + multiprocessing work
             import pyxrootd.client
         except ImportError:
             raise ImportError("Install pyxrootd package with:\n    conda install -c conda-forge xrootd\n(or download from http://xrootd.org/dload.html and manually compile with cmake; setting PYTHONPATH and LD_LIBRARY_PATH appropriately).")

--- a/uproot/source/xrootd.py
+++ b/uproot/source/xrootd.py
@@ -21,6 +21,9 @@ class XRootDSource(uproot.source.chunked.ChunkedSource):
 
     def _open(self):
         try:
+            import os
+            # To make uproot + xrootd + multiprocessing work
+            os.environ['XRD_RUNFORKHANDLER'] = '1'
             import pyxrootd.client
         except ImportError:
             raise ImportError("Install pyxrootd package with:\n    conda install -c conda-forge xrootd\n(or download from http://xrootd.org/dload.html and manually compile with cmake; setting PYTHONPATH and LD_LIBRARY_PATH appropriately).")


### PR DESCRIPTION
By setting the appropriate environment variable.

The bug this fixes is a hang in child processes triggered by use of uproot with XRootD files in multiprocessing or concurrent.futures process pools after doing so in the parent process.  An example that triggers the bug is below:
```python
#!/usr/bin/env python
import concurrent.futures
import uproot

file = "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root"

def read(fn):
    print("starting work")
    with uproot.open(fn) as f:
        print("opened file")
        sumw = f['Events'].numentries
    return sumw

print(read(file))

with concurrent.futures.ProcessPoolExecutor(max_workers=1) as executor:
    future = executor.submit(read, file)
    print(future.result())
```