### PR TITLE
Faster travis tests using mamba

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,17 +37,23 @@ install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --add channels conda-forge;
+  - conda install --quiet --yes -c conda-forge/label/mamba-alpha mamba
   - conda config --set always_yes yes --set changeps1 no
   # Create the conda testing environment
+  # FIXME: Mamba decides to upgrade Python here so pin it again
   # FIXME: Channel priority is also mixed up
+  # FIXME: Mamba doesn't install pip by default
+  # FIXME: Mamba causes pip install numpy to be extremely slow
   - if [[ "${PYVER}" = pypy* ]]; then
       conda create --quiet --yes -n testenv ${PYVER};
+    elif [ "${PYVER}" = "2.7" ] || [ "${PYVER}" = "3.6" ] || [ "${PYVER}" = "3.7" ]; then
+      mamba create --quiet --yes -n testenv python=${PYVER} pip;
     else
       conda create --quiet --yes -n testenv python=${PYVER};
     fi
   - source activate testenv
   - if [ "${PYVER}" = "2.7" ] || [ "${PYVER}" = "3.6" ] || [ "${PYVER}" = "3.7" ]; then
-      conda install --quiet --yes python=${PYVER} root;
+      mamba install --quiet --yes python=${PYVER} pip root;
       source activate testenv;
     fi
   - pip install --upgrade setuptools-scm
@@ -63,7 +69,7 @@ install:
   - pip install pandas
   # pyopenssl is for deployment
   - if [[ ${PYVER} != pypy* ]] ; then
-      conda install -c anaconda python=${PYVER} pyopenssl;
+      mamba install -c anaconda python=${PYVER} pyopenssl;
     fi
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,7 @@ install:
   - if [[ ${PYVER} != pypy* ]] ; then
       mamba install -c anaconda python=${PYVER} pyopenssl;
     fi
+  - wget -O tests/Event.root http://scikit-hep.org/uproot/examples/Event.root
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ install:
   - if [[ ${PYVER} != pypy* ]] ; then
       mamba install -c anaconda python=${PYVER} pyopenssl;
     fi
-  - wget -O tests/Event.root http://scikit-hep.org/uproot/examples/Event.root
+  - wget -O tests/samples/Event.root http://scikit-hep.org/uproot/examples/Event.root
 
 addons:
   apt:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,4 +53,6 @@ build_script:
   - "pip install cachetools"
   - "pip install -i https://pypi.anaconda.org/carlkl/simple backports.lzma"
   - "pip install pytest pytest-runner pandas requests"
-  - "python setup.py pytest"
+  - "python setup.py"
+  - "curl -fsS -o tests/samples/Event.root http://scikit-hep.org/uproot/examples/Event.root"
+  - "pytest -v tests"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,6 +53,5 @@ build_script:
   - "pip install cachetools"
   - "pip install -i https://pypi.anaconda.org/carlkl/simple backports.lzma"
   - "pip install pytest pytest-runner pandas requests"
-  - "python setup.py"
   - "curl -fsS -o tests/samples/Event.root http://scikit-hep.org/uproot/examples/Event.root"
-  - "pytest -v tests"
+  - "python setup.py pytest"

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -584,10 +584,9 @@ class Test(unittest.TestCase):
                 assert normalize(lazy[i - 1 : i + 3]) == strict[i - 1 : i + 3].tolist()
 
     def test_hist_in_tree(self):
-        path = os.path.join("samples", "Event.root")
+        path = os.path.join("tests", "samples", "Event.root")
         if os.path.exists(path):
             tree = uproot.open(path)["T"]
-            print("Debugging")
         else:
             tree = uproot.open("http://scikit-hep.org/uproot/examples/Event.root")["T"]
         check = [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
@@ -612,7 +611,7 @@ class Test(unittest.TestCase):
             b'fTriggerBits',
             b'fTriggerBits.TObject'
         ]
-        path = os.path.join("samples", "Event.root")
+        path = os.path.join("tests", "samples", "Event.root")
         if os.path.exists(path):
             tree = uproot.open(path)["T"]
         else:

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -2,7 +2,6 @@
 
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot/blob/master/LICENSE
 
-import os
 import unittest
 
 from collections import namedtuple
@@ -583,7 +582,7 @@ class Test(unittest.TestCase):
             for i in range(len(lazy), 0, -1):
                 assert normalize(lazy[i - 1 : i + 3]) == strict[i - 1 : i + 3].tolist()
 
-    @pytest.mark.skip(reason="Appveyor and Travis sometimes fails")
+    @pytest.mark.skip(reason="Unable to download Event.root at times")
     def test_hist_in_tree(self):
         tree = uproot.open("http://scikit-hep.org/uproot/examples/Event.root")["T"]
         check = [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
@@ -596,7 +595,7 @@ class Test(unittest.TestCase):
 
         assert tree.array("fH")[20].values.tolist() == check
 
-    @pytest.mark.skip(reason="Appveyor and Travis sometimes fails")
+    @pytest.mark.skip(reason="Unable to download Event.root at times")
     def test_branch_auto_interpretation(self):
         # The aim is to reduce this list in a controlled manner
         known_branches_without_interp = [

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -584,10 +584,10 @@ class Test(unittest.TestCase):
                 assert normalize(lazy[i - 1 : i + 3]) == strict[i - 1 : i + 3].tolist()
 
     def test_hist_in_tree(self):
-        if os.name == "nt":
-            pytest.skip("AppVeyor sometimes can't load Event.root")
-        if os.path.exists("samples/Event.root"):
-            tree = uproot.open("samples/Event.root")["T"]
+        path = os.path.join("samples", "Event.root")
+        if os.path.exists(path):
+            tree = uproot.open(path)["T"]
+            print("Debugging")
         else:
             tree = uproot.open("http://scikit-hep.org/uproot/examples/Event.root")["T"]
         check = [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
@@ -601,8 +601,6 @@ class Test(unittest.TestCase):
         assert tree.array("fH")[20].values.tolist() == check
 
     def test_branch_auto_interpretation(self):
-        if os.name == "nt":
-            pytest.skip("AppVeyor sometimes can't load Event.root")
         # The aim is to reduce this list in a controlled manner
         known_branches_without_interp = [
             b'event',
@@ -614,8 +612,9 @@ class Test(unittest.TestCase):
             b'fTriggerBits',
             b'fTriggerBits.TObject'
         ]
-        if os.path.exists("samples/Event.root"):
-            tree = uproot.open("samples/Event.root")["T"]
+        path = os.path.join("samples", "Event.root")
+        if os.path.exists(path):
+            tree = uproot.open(path)["T"]
         else:
             tree = uproot.open("http://scikit-hep.org/uproot/examples/Event.root")["T"]
         branches_without_interp = [b.name for b in tree.allvalues() if b.interpretation is None]

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -583,10 +583,8 @@ class Test(unittest.TestCase):
             for i in range(len(lazy), 0, -1):
                 assert normalize(lazy[i - 1 : i + 3]) == strict[i - 1 : i + 3].tolist()
 
+    @pytest.mark.skip(reason="Appveyor and Travis sometimes fails")
     def test_hist_in_tree(self):
-        if os.name == "nt":
-            pytest.skip("AppVeyor sometimes can't load Event.root")
-
         tree = uproot.open("http://scikit-hep.org/uproot/examples/Event.root")["T"]
         check = [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
                  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0,
@@ -598,10 +596,8 @@ class Test(unittest.TestCase):
 
         assert tree.array("fH")[20].values.tolist() == check
 
+    @pytest.mark.skip(reason="Appveyor and Travis sometimes fails")
     def test_branch_auto_interpretation(self):
-        if os.name == "nt":
-            pytest.skip("AppVeyor sometimes can't load Event.root")
-
         # The aim is to reduce this list in a controlled manner
         known_branches_without_interp = [
             b'event',

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -2,6 +2,7 @@
 
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot/blob/master/LICENSE
 
+import os
 import unittest
 
 from collections import namedtuple
@@ -582,9 +583,13 @@ class Test(unittest.TestCase):
             for i in range(len(lazy), 0, -1):
                 assert normalize(lazy[i - 1 : i + 3]) == strict[i - 1 : i + 3].tolist()
 
-    @pytest.mark.skip(reason="Unable to download Event.root at times")
     def test_hist_in_tree(self):
-        tree = uproot.open("http://scikit-hep.org/uproot/examples/Event.root")["T"]
+        if os.name == "nt":
+            pytest.skip("AppVeyor sometimes can't load Event.root")
+        if os.path.exists("samples/Event.root"):
+            tree = uproot.open("samples/Event.root")["T"]
+        else:
+            tree = uproot.open("http://scikit-hep.org/uproot/examples/Event.root")["T"]
         check = [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
                  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0,
                  1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
@@ -595,8 +600,9 @@ class Test(unittest.TestCase):
 
         assert tree.array("fH")[20].values.tolist() == check
 
-    @pytest.mark.skip(reason="Unable to download Event.root at times")
     def test_branch_auto_interpretation(self):
+        if os.name == "nt":
+            pytest.skip("AppVeyor sometimes can't load Event.root")
         # The aim is to reduce this list in a controlled manner
         known_branches_without_interp = [
             b'event',
@@ -608,7 +614,10 @@ class Test(unittest.TestCase):
             b'fTriggerBits',
             b'fTriggerBits.TObject'
         ]
-        tree = uproot.open("http://scikit-hep.org/uproot/examples/Event.root")["T"]
+        if os.path.exists("samples/Event.root"):
+            tree = uproot.open("samples/Event.root")["T"]
+        else:
+            tree = uproot.open("http://scikit-hep.org/uproot/examples/Event.root")["T"]
         branches_without_interp = [b.name for b in tree.allvalues() if b.interpretation is None]
         assert branches_without_interp == known_branches_without_interp
         assert tree.array("fTracks.fTArray[3]", entrystop=10)[5][10].tolist()  == [11.03951644897461, 19.40645980834961, 34.54059982299805]


### PR DESCRIPTION
If we skip the 2 tests that require Event.root (we were skipping those in appveyor already) in travis as well, mamba works. 
This PR adds speed to travis tests(by reverting to using mamba instead of conda) at the cost of skipping 2 tests. I am not sure if this is something we want, please close this PR if we do not. 

(Not related to this PR - Appveyor tests sometimes fail on any random job because of `Could not resolve host: github.com` while trying to git clone uproot.)