### PR TITLE
Use curl -L to have trigger_binder follow URL redirect

### DIFF
--- a/binder/trigger_binder.sh
+++ b/binder/trigger_binder.sh
@@ -3,7 +3,7 @@
 function trigger_binder() {
     local URL="${1}"
 
-    curl --connect-timeout 10 --max-time 30 "${URL}"
+    curl -L --connect-timeout 10 --max-time 30 "${URL}"
     curl_return=$?
 
     # Return code 28 is when the --max-time is reached


### PR DESCRIPTION
# Description

BinderHub now operates as a Binder Federation and so there is no guarantee where the Binder build will take place. As a result, the Binder trigger must follow any redirect of the URL.

c.f.
https://discourse.jupyter.org/t/problem-triggering-binder-build-through-api-endpoint/1440