### PR TITLE
Propagate FileSource futures setup to threadlocal

### DIFF
--- a/uproot/source/file.py
+++ b/uproot/source/file.py
@@ -18,6 +18,7 @@ class FileSource(uproot.source.chunked.ChunkedSource):
 
     def __init__(self, path, *args, **kwds):
         self._size = None
+        self._parallel = kwds['parallel']
         super(FileSource, self).__init__(os.path.expanduser(path), *args, **kwds)
 
     def size(self):
@@ -31,6 +32,7 @@ class FileSource(uproot.source.chunked.ChunkedSource):
         out._chunkbytes = self._chunkbytes
         out.cache = self.cache
         out._source = None             # local file connections are *not shared* among threads (they're *not* thread-safe)
+        out._setup_futures(self._parallel)
         return out
 
     def _open(self):


### PR DESCRIPTION
This fixes a bug when using non-memmapped files in separate threads:
https://github.com/CoffeaTeam/coffea/pull/118

(it's the reason tests are failing right now in that PR)

If there's a better way to implement this fix please let me know!