### PR TITLE
Trigger Binder builds on both GKE and OVH clusters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,5 +109,6 @@ jobs:
     before_install: skip
     install: skip
     script:
-    # Use Binder build API to trigger repo2docker to build image
-    - bash binder/trigger_binder.sh https://mybinder.org/build/gh/scikit-hep/uproot/"${TRAVIS_BRANCH}"
+    # Use Binder build API to trigger repo2docker to build image on GKE and OVH Binder Federation clusters
+    - bash binder/trigger_binder.sh https://gke.mybinder.org/build/gh/scikit-hep/uproot/"${TRAVIS_BRANCH}"
+    - bash binder/trigger_binder.sh https://ovh.mybinder.org/build/gh/scikit-hep/uproot/"${TRAVIS_BRANCH}"


### PR DESCRIPTION
# Description

Amends PR #292 

Given that the Binder Federation exists on both GKE and OVH there is no guarantee that the cluster that a build is triggered on is the same cluster that a user will be directed to when they launch the Binder. As a result, both clusters should be triggered when a PR is merged.

c.f. https://discourse.jupyter.org/t/the-binder-federation/1286