### PR TITLE
depend on awkward 0.12+ to fix tree.pandas.df

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ install:
   - pip install --upgrade setuptools-scm
   - pip install $NPY
   - python -c 'import numpy; print(numpy.__version__)'
-  - pip install "awkward>=0.11.0"
+  - pip install "awkward>=0.12.0"
   - python -c 'import awkward; print(awkward.__version__)'
   - pip install "uproot-methods>=0.7.0"
   - python -c 'import uproot_methods; print(uproot_methods.__version__)'

--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ Strict dependencies:
 --------------------
 
 - `numpy <https://scipy.org/install.html>`__ (1.13.1+)
-- `awkward-array <https://github.com/scikit-hep/awkward-array>`__ (0.11.0+)
+- `awkward-array <https://github.com/scikit-hep/awkward-array>`__ (0.12.0+)
 - `uproot-methods <https://github.com/scikit-hep/uproot-methods>`__ (0.7.0+)
 - `cachetools <https://pypi.org/project/cachetools>`__
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,7 @@ install:
 build_script:
   - "python -m pip install --upgrade pip"
   - "pip install %NUMPY%"
-  - "pip install \"awkward>=0.11.0\""
+  - "pip install \"awkward>=0.12.0\""
   - "python -c \"import awkward; print(awkward.__version__)\""
   - "pip install \"uproot-methods>=0.7.0\""
   - "python -c \"import uproot_methods; print(uproot_methods.__version__)\""

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.13.1
-awkward>=0.11.0
+awkward>=0.12.0
 uproot-methods>=0.7.0
 cachetools
 pkgconfig

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.13.1
-awkward>=0.11.0
+awkward>=0.12.0
 uproot-methods>=0.7.0
 cachetools
 backports.lzma;python_version<"3.3"

--- a/setup.py
+++ b/setup.py
@@ -141,7 +141,7 @@ setup(name = "uproot",
       download_url = "https://github.com/scikit-hep/uproot/releases",
       license = "BSD 3-clause",
       test_suite = "tests",
-      install_requires = ["numpy>=1.13.1", "awkward>=0.11.0", "uproot-methods>=0.7.0", "cachetools"],
+      install_requires = ["numpy>=1.13.1", "awkward>=0.12.0", "uproot-methods>=0.7.0", "cachetools"],
       setup_requires = ["pytest-runner"],
       tests_require = ["pytest>=3.9", "pkgconfig", "lz4", 'backports.lzma;python_version<"3.3"', "xxhash", "mock", "requests"],
       classifiers = [

--- a/uproot/_connect/_pandas.py
+++ b/uproot/_connect/_pandas.py
@@ -121,7 +121,7 @@ def futures2df(futures, outputtype, entrystart, entrystop, flatten, flatname, aw
                 if starts is None:
                     starts = array.starts
                     stops = array.stops
-                    index = array.index
+                    index = array.localindex
                 else:
                     if starts is not array.starts and not awkward.numpy.array_equal(starts, array.starts):
                         raise ValueError("cannot use flatten=True on branches with different jagged structure, such as electrons and muons (different, variable number of each per event); either explicitly select compatible branches, such as [\"MET_*\", \"Muon_*\"] (scalar and variable per event is okay), or set flatten=False")

--- a/uproot/version.py
+++ b/uproot/version.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 
 import re
 
-__version__ = "3.7.2"
+__version__ = "3.8.0"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
The `JaggedArray.index` changed its name to `JaggedArray.localindex` and apparently, `TTree.pandas.df` depended on the old name. Setting the minimum awkward version to 0.12.0 fixes that.