### PR TITLE
Fixed extend for flush=True

### DIFF
--- a/uproot/write/objects/TTree.py
+++ b/uproot/write/objects/TTree.py
@@ -106,8 +106,8 @@ class TTree(object):
             raise Exception("Baskets of all branches should have the same length")
 
         if flush:
-            for key, value in branchdict.items():
-                self._branches[key].newbasket(value)
+            self.extend(branchdict, flush=False)
+            self.flush()
         else:
             for key, value in branchdict.items():
                 for x in value:


### PR DESCRIPTION
Fixes extend with flush=True (even though it is still using the inefficient implementation of flush=False).
Even after the better(and correct) implementation of flush=False for extend, the code under the flush=True block should probably not change.

Although, in its current implementation this makes extend=True less efficient, the implementation is now correct.