### PR TITLE
Reading files with HTTP fails if range headers are not supported

### DIFF
--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -47,8 +47,8 @@ class Test(unittest.TestCase):
         before = before_hadd.arrays()
         after = after_hadd.arrays()
 
-        assert set(before.keys()), se == ([b"v_int16", b"v_int32", b"v_int64", b"v_uint16", b"v_uint32", b"v_uint64", b"v_bool", b"v_float", b"v_double"])
-        assert set(after.keys()),  se == ([b"v_int16", b"v_int32", b"v_int64", b"v_uint16", b"v_uint32", b"v_uint64", b"v_bool", b"v_float", b"v_double"])
+        assert set(before.keys())
+        assert set(after.keys())
 
         for key in before.keys():
             assert before[key].tolist() * 3 == after[key].tolist()

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -559,7 +559,7 @@ class Test(unittest.TestCase):
             for i in range(len(lazy), 0, -1):
                 assert lazy[branchname][i - 1 : i + 3].tolist() == strict[i - 1 : i + 3].tolist()
 
-    def test_tree_lazy2(self):
+    def test_tree_lazy3(self):
         lazy = uproot.lazyarrays(["tests/samples/sample-5.29.02-uncompressed.root", "tests/samples/sample-5.30.00-uncompressed.root"], "sample")
 
         assert lazy["u1"].tolist() == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29]

--- a/uproot/interp/auto.py
+++ b/uproot/interp/auto.py
@@ -200,7 +200,7 @@ def interpret(branch, awkwardlib=None, swapbytes=True, cntvers=False, tobject=Tr
                             numbits = None
                         else:
                             low, high, numbits = spec
-                    except:
+                    except Exception:
                         return None
 
                 if iskDouble32 and numbits == 0:

--- a/uproot/interp/jagged.py
+++ b/uproot/interp/jagged.py
@@ -36,15 +36,12 @@ class asjagged(uproot.interp.interp.Interpretation):
         self.skipbytes = skipbytes
 
     def __repr__(self):
-        return "asjagged({0})".format(repr(self.content))
+        return "asjagged({0}{1})".format(repr(self.content), "" if self.skipbytes == 0 else ", {0}".format(self.skipbytes))
 
     def to(self, todtype=None, todims=None, skipbytes=None):
         if skipbytes is None:
             skipbytes = self.skipbytes
         return asjagged(self.content.to(todtype, todims), skipbytes)
-
-    def __repr__(self):
-        return "asjagged({0}{1})".format(repr(self.content), "" if self.skipbytes == 0 else ", {0}".format(self.skipbytes))
 
     @property
     def identifier(self):

--- a/uproot/rootio.py
+++ b/uproot/rootio.py
@@ -166,7 +166,7 @@ class ROOTDirectory(object):
 
                 return ROOTDirectory.read(source, Cursor(fBEGIN + fNbytesName), context, mykey)
 
-            except:
+            except Exception:
                 source.dismiss()
                 raise
 

--- a/uproot/source/chunked.py
+++ b/uproot/source/chunked.py
@@ -123,7 +123,9 @@ class ChunkedSource(uproot.source.source.Source):
 
             if len(chunk) > self._chunkbytes:
                 if len(chunk) > self._limitbytes:
-                    warnings.warn('Received larger chunk than expected, assumed to be entire file. Performance may be significantly degraded.', RuntimeWarning)
+                    warnings.warn('Remote server sent a larger chunk than expected, assumed to be entire file. '
+                                  'Performance will be degraded as the file is larger than the cache limit and might need to be downloaded many times.',
+                                  RuntimeWarning)
                 for i in range(0, len(chunk), self._chunkbytes):
                     if i // self._chunkbytes not in self.cache:
                         self.cache[i // self._chunkbytes] = chunk[i:i+self._chunkbytes]

--- a/uproot/source/chunked.py
+++ b/uproot/source/chunked.py
@@ -125,6 +125,8 @@ class ChunkedSource(uproot.source.source.Source):
                 warnings.warn('Received larger chunk than expected, assumed to be entire file. Performance may be significantly degraded.', RuntimeWarning)
                 for i in range(0, len(chunk), self._chunkbytes):
                     self.cache[i//self._chunkbytes] = chunk[i:i+self._chunkbytes]
+                # Dismiss any pending futures as everything has already been loaded
+                self.dismiss()
                 chunk = self.cache[chunkindex]
             else:
                 self.cache[chunkindex] = chunk

--- a/uproot/source/compressed.py
+++ b/uproot/source/compressed.py
@@ -119,7 +119,7 @@ class CompressedSource(uproot.source.source.Source):
                 # https://github.com/root-project/root/blob/master/core/zip/src/RZip.cxx#L217
                 # https://github.com/root-project/root/blob/master/core/lzma/src/ZipLZMA.c#L81
                 # https://github.com/root-project/root/blob/master/core/lz4/src/ZipLZ4.cxx#L38
-                algo, method, c1, c2, c3, u1, u2, u3 = cursor.fields(self._compressed, self._header)
+                algo, method, c1, c2, c3, u1, u2, u3 = header = cursor.fields(self._compressed, self._header)
                 compressedbytes = c1 + (c2 << 8) + (c3 << 16)
                 uncompressedbytes = u1 + (u2 << 8) + (u3 << 16)
 

--- a/uproot/tree.py
+++ b/uproot/tree.py
@@ -1816,17 +1816,17 @@ class _LazyFiles(object):
             self.keycache = cachetools.LRUCache(10000)                      # last 10000 TKeys
 
     def __getstate__(self):
-        return {"paths": paths,
-                "treepath": treepath,
-                "branches": branches,
-                "entrysteps": entrysteps,
-                "flatten": flatten,
-                "awkwardlib": awkwardlib,
-                "persistvirtual": persistvirtual,
-                "localsource": localsource,
-                "xrootdsource": xrootdsource,
-                "httpsource": httpsource,
-                "options": options}
+        return {"paths": self.paths,
+                "treepath": self.treepath,
+                "branches": self.branches,
+                "entrysteps": self.entrysteps,
+                "flatten": self.flatten,
+                "awkwardlib": self.awkwardlib,
+                "persistvirtual": self.persistvirtual,
+                "localsource": self.localsource,
+                "xrootdsource": self.xrootdsource,
+                "httpsource": self.httpsource,
+                "options": self.options}
                 
     def __setstate__(self, state):
         self.paths = state["paths"]

--- a/uproot/tree.py
+++ b/uproot/tree.py
@@ -812,7 +812,7 @@ class TTreeMethods(object):
         else:
             try:
                 words = iter(arg)                          # only way to check for iterable (in general)
-            except:
+            except Exception:
                 raise TypeError("'branches' argument not understood")
             else:
                 for word in words:
@@ -1281,7 +1281,7 @@ class TBranchMethods(object):
                     basket = (local_entrystart + self.basket_entrystart(j + basketstart),
                               local_entrystop + self.basket_entrystart(j + basketstart),
                               basket)
-            except:
+            except Exception:
                 return sys.exc_info()
             else:
                 out[j] = basket
@@ -1412,7 +1412,7 @@ class TBranchMethods(object):
                                     basket_entryoffset[j],
                                     basket_entryoffset[j + 1])
 
-            except:
+            except Exception:
                 return sys.exc_info()
 
         if executor is None:
@@ -1489,7 +1489,7 @@ class TBranchMethods(object):
                                     basket_entryoffset[j],
                                     basket_entryoffset[j + 1])
 
-            except:
+            except Exception:
                 return sys.exc_info()
 
         if executor is None:
@@ -2048,7 +2048,7 @@ def _numentries(paths, treepath, total, localsource, xrootdsource, httpsource, e
     def fill(i):
         try:
             file = uproot.rootio.open(paths[i], localsource=localsource, xrootdsource=xrootdsource, httpsource=httpsource, read_streamers=False, **options)
-        except:
+        except Exception:
             return sys.exc_info()
         else:
             try:
@@ -2059,7 +2059,7 @@ def _numentries(paths, treepath, total, localsource, xrootdsource, httpsource, e
                 except KeyError:
                     out[i] = 0
                 uuids[i] = file._context.uuid
-            except:
+            except Exception:
                 return sys.exc_info()
             else:
                 return None


### PR DESCRIPTION
Uproot fails to read files from servers that don't support range requests. Example traceback with extra debugging print out and without this fix applied:
```
Got response of size 20166303 chunksize is 1048576
-1765915941 -30694 -1671616656 4090602292 -7813 16221 -118717542 708660270
self._compressedbytes, self._uncompressedbytes = -1765908128 -1671616656
cursor.index - start 0
self._compressedbytes -1765908128
self._uncompressed = None
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "uproot/rootio.py", line 60, in open
    return http(path, httpsource=httpsource, **options)
  File "uproot/rootio.py", line 89, in http
    return ROOTDirectory.read(openfcn(path), **options)
  File "uproot/rootio.py", line 154, in read
    streamerinfos, streamerinfosmap, streamerrules = _readstreamers(streamerkey._source, streamerkey._cursor, streamercontext, None)
  File "uproot/rootio.py", line 556, in _readstreamers
    tlist = TList.read(source, cursor, context, parent)
  File "uproot/rootio.py", line 949, in read
    out = cls._readinto(out, source, cursor, context, parent)
  File "uproot/rootio.py", line 1455, in _readinto
    start, cnt, self._classversion = _startcheck(source, cursor)
  File "uproot/rootio.py", line 426, in _startcheck
    cnt, vers = cursor.fields(source, _startcheck._format_cntvers)
  File "uproot/source/cursor.py", line 46, in fields
    return format.unpack(source.data(start, stop))
  File "uproot/source/compressed.py", line 183, in data
    return self._uncompressed[start:stop]
TypeError: 'NoneType' object is not subscriptable
```

Error can be seen when using Python's built in HTTP server to open a "large" file (i.e. more than one chunk):
```bash
python -m http.server 8000 --directory tests/samples
```

Also includes some minor fixes for linter errors I stumbled upon. It might be necessary to use a more general exception in some cases. I've not checked closely but perhaps `SyntaxError` needs to be caught in some cases?