### PR TITLE
Avoid misleading error message by return 0 for numbaskets if interpretation is None

### DIFF
--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -15,6 +15,7 @@ import awkward
 import uproot_methods.classes.TVector3
 import uproot_methods.classes.TLorentzVector
 
+
 class Test(unittest.TestCase):
     def test_issue21(self):
         t = uproot.open("tests/samples/issue21.root")["nllscan"]
@@ -27,22 +28,49 @@ class Test(unittest.TestCase):
         assert t["mH"].basket_entrystart(0) == 0
         assert t["mH"].basket_entrystop(0) == 61
         assert t["mH"].basket_numentries(0) == 61
-        assert t.array("mH").tolist() == [124.0, 124.09089660644531, 124.18180084228516, 124.27269744873047, 124.36360168457031, 124.45449829101562, 124.54550170898438, 124.63639831542969, 124.72730255126953, 124.81819915771484, 124.87000274658203, 124.87550354003906, 124.88089752197266, 124.88639831542969, 124.89179992675781, 124.89730072021484, 124.90270233154297, 124.908203125, 124.90910339355469, 124.9135971069336, 124.91909790039062, 124.92449951171875, 124.93000030517578, 124.98739624023438, 124.9906997680664, 124.99349975585938, 124.99590301513672, 124.9977035522461, 124.9990005493164, 124.99970245361328, 125.0, 125.00029754638672, 125.0009994506836, 125.0022964477539, 125.00409698486328, 125.00650024414062, 125.0093002319336, 125.01260375976562, 125.06999969482422, 125.07550048828125, 125.08090209960938, 125.0864028930664, 125.09089660644531, 125.091796875, 125.09729766845703, 125.10269927978516, 125.10820007324219, 125.11360168457031, 125.11910247802734, 125.12449645996094, 125.12999725341797, 125.18180084228516, 125.27269744873047, 125.36360168457031, 125.45449829101562, 125.54550170898438, 125.63639831542969, 125.72730255126953, 125.81819915771484, 125.90910339355469, 126.0]
+        assert t.array("mH").tolist() == [
+            124.0, 124.09089660644531, 124.18180084228516, 124.27269744873047,
+            124.36360168457031, 124.45449829101562, 124.54550170898438,
+            124.63639831542969, 124.72730255126953, 124.81819915771484,
+            124.87000274658203, 124.87550354003906, 124.88089752197266,
+            124.88639831542969, 124.89179992675781, 124.89730072021484,
+            124.90270233154297, 124.908203125, 124.90910339355469,
+            124.9135971069336, 124.91909790039062, 124.92449951171875,
+            124.93000030517578, 124.98739624023438, 124.9906997680664,
+            124.99349975585938, 124.99590301513672, 124.9977035522461,
+            124.9990005493164, 124.99970245361328, 125.0, 125.00029754638672,
+            125.0009994506836, 125.0022964477539, 125.00409698486328,
+            125.00650024414062, 125.0093002319336, 125.01260375976562,
+            125.06999969482422, 125.07550048828125, 125.08090209960938,
+            125.0864028930664, 125.09089660644531, 125.091796875,
+            125.09729766845703, 125.10269927978516, 125.10820007324219,
+            125.11360168457031, 125.11910247802734, 125.12449645996094,
+            125.12999725341797, 125.18180084228516, 125.27269744873047,
+            125.36360168457031, 125.45449829101562, 125.54550170898438,
+            125.63639831542969, 125.72730255126953, 125.81819915771484,
+            125.90910339355469, 126.0
+        ]
 
     def test_issue30(self):
         uproot.open("tests/samples/issue30.root")
 
     def test_issue31(self):
         t = uproot.open("tests/samples/issue31.root")["T"]
-        assert t.array("name").tolist() == [b"one", b"two", b"three", b"four", b"five"]
+        assert t.array("name").tolist() == [
+            b"one", b"two", b"three", b"four", b"five"
+        ]
 
     def test_issue33(self):
         h = uproot.open("tests/samples/issue33.root")["cutflow"]
-        assert h.xlabels == ["Dijet", "MET", "MuonVeto", "IsoMuonTrackVeto", "ElectronVeto", "IsoElectronTrackVeto", "IsoPionTrackVeto"]
+        assert h.xlabels == [
+            "Dijet", "MET", "MuonVeto", "IsoMuonTrackVeto", "ElectronVeto",
+            "IsoElectronTrackVeto", "IsoPionTrackVeto"
+        ]
 
     def test_issue38(self):
-        before_hadd = uproot.open("tests/samples/issue38a.root")["ntupler/tree"]
-        after_hadd  = uproot.open("tests/samples/issue38b.root")["ntupler/tree"]
+        before_hadd = uproot.open(
+            "tests/samples/issue38a.root")["ntupler/tree"]
+        after_hadd = uproot.open("tests/samples/issue38b.root")["ntupler/tree"]
 
         before = before_hadd.arrays()
         after = after_hadd.arrays()
@@ -66,10 +94,14 @@ class Test(unittest.TestCase):
         assert h._fFunctions[0]._fParent is h
 
     def test_issue55(self):
-        withoffsets = uproot.open("tests/samples/small-dy-withoffsets.root")["tree"]
-        nooffsets = uproot.open("tests/samples/small-dy-nooffsets.root")["tree"]
-        assert numpy.array_equal(withoffsets.array("nJet"), nooffsets.array("nJet"))
-        assert numpy.array_equal(withoffsets.array("nMuon"), nooffsets.array("nMuon"))
+        withoffsets = uproot.open(
+            "tests/samples/small-dy-withoffsets.root")["tree"]
+        nooffsets = uproot.open(
+            "tests/samples/small-dy-nooffsets.root")["tree"]
+        assert numpy.array_equal(withoffsets.array("nJet"),
+                                 nooffsets.array("nJet"))
+        assert numpy.array_equal(withoffsets.array("nMuon"),
+                                 nooffsets.array("nMuon"))
 
         def equal(left, right):
             if len(left) != len(right):
@@ -79,10 +111,12 @@ class Test(unittest.TestCase):
                     return False
             return True
 
-        assert equal(withoffsets.array("Jet_jetId"), nooffsets.array("Jet_jetId"))
+        assert equal(withoffsets.array("Jet_jetId"),
+                     nooffsets.array("Jet_jetId"))
         assert equal(withoffsets.array("Jet_pt"), nooffsets.array("Jet_pt"))
         assert equal(withoffsets.array("MET_pt"), nooffsets.array("MET_pt"))
-        assert equal(withoffsets.array("Muon_charge"), nooffsets.array("Muon_charge"))
+        assert equal(withoffsets.array("Muon_charge"),
+                     nooffsets.array("Muon_charge"))
         assert equal(withoffsets.array("Muon_pt"), nooffsets.array("Muon_pt"))
         assert equal(withoffsets.array("event"), nooffsets.array("event"))
 
@@ -90,21 +124,40 @@ class Test(unittest.TestCase):
         tree = uproot.open("tests/samples/issue57.root")["outtree"]
         for x in tree["sel_lep"].array():
             for y in x:
-                assert isinstance(y, uproot_methods.classes.TLorentzVector.Methods) and isinstance(y._fP, uproot_methods.classes.TVector3.Methods)
+                assert isinstance(
+                    y, uproot_methods.classes.TLorentzVector.
+                    Methods) and isinstance(
+                        y._fP, uproot_methods.classes.TVector3.Methods)
         for x in tree["selJet"].array():
             for y in x:
-                assert isinstance(y, uproot_methods.classes.TLorentzVector.Methods) and isinstance(y._fP, uproot_methods.classes.TVector3.Methods)
+                assert isinstance(
+                    y, uproot_methods.classes.TLorentzVector.
+                    Methods) and isinstance(
+                        y._fP, uproot_methods.classes.TVector3.Methods)
 
     def test_issue60(self):
         t = uproot.open("tests/samples/issue60.root")["nllscan"]
 
         assert t["status"].numbaskets == 2
         assert t["mH"].numbaskets == 3
-        assert (t["mH"].basket_entrystart(0), t["mH"].basket_entrystart(1), t["mH"].basket_entrystart(2)) == (0, 3990, 7980)
-        assert (t["mH"].basket_entrystop(0), t["mH"].basket_entrystop(1), t["mH"].basket_entrystop(2)) == (3990, 7980, 11535)
-        assert (t["mH"].basket_numentries(0), t["mH"].basket_numentries(1), t["mH"].basket_numentries(2)) == (3990, 3990, 3555)
-        assert t.array("mH")[:10].tolist() == [125.3575896071691, 124.75819175713684, 124.79865223661515, 125.13239376420276, 125.19612659731995, 125.33001837818416, 124.93261741760551, 125.02903289132837, 124.65206649938854, 125.50663519903532]
-        assert t.array("mH")[-10:].tolist() == [125.5150930345707, 125.00248572708085, 124.55838505657864, 125.03766816520313, 125.27765299737514, 124.9976442776121, 124.8339210081154, 124.62415638855144, 125.33988981473144, 124.93384515492096]
+        assert (t["mH"].basket_entrystart(0), t["mH"].basket_entrystart(1),
+                t["mH"].basket_entrystart(2)) == (0, 3990, 7980)
+        assert (t["mH"].basket_entrystop(0), t["mH"].basket_entrystop(1),
+                t["mH"].basket_entrystop(2)) == (3990, 7980, 11535)
+        assert (t["mH"].basket_numentries(0), t["mH"].basket_numentries(1),
+                t["mH"].basket_numentries(2)) == (3990, 3990, 3555)
+        assert t.array("mH")[:10].tolist() == [
+            125.3575896071691, 124.75819175713684, 124.79865223661515,
+            125.13239376420276, 125.19612659731995, 125.33001837818416,
+            124.93261741760551, 125.02903289132837, 124.65206649938854,
+            125.50663519903532
+        ]
+        assert t.array("mH")[-10:].tolist() == [
+            125.5150930345707, 125.00248572708085, 124.55838505657864,
+            125.03766816520313, 125.27765299737514, 124.9976442776121,
+            124.8339210081154, 124.62415638855144, 125.33988981473144,
+            124.93384515492096
+        ]
 
     def test_issue63(self):
         t = uproot.open("tests/samples/issue63.root")["WtLoop_meta"]
@@ -120,7 +173,27 @@ class Test(unittest.TestCase):
     def test_issue66(self):
         f = uproot.open("tests/samples/issue66.root")
         h, = f.values()
-        assert h.values.tolist() == [4814.0, 45.0, 45.0, 25.0, 15.0, 4.0, 0.0, 6.0, 7.0, 5.0, 3.0, 3.0, 6.0, 3.0, 7.0, 5.0, 7.0, 11.0, 9.0, 5.0, 4.0, 10.0, 12.0, 7.0, 10.0, 8.0, 12.0, 11.0, 12.0, 12.0, 14.0, 15.0, 13.0, 14.0, 14.0, 20.0, 20.0, 16.0, 21.0, 22.0, 22.0, 28.0, 25.0, 33.0, 26.0, 21.0, 42.0, 36.0, 43.0, 42.0, 43.0, 39.0, 42.0, 56.0, 67.0, 50.0, 67.0, 71.0, 59.0, 76.0, 73.0, 84.0, 63.0, 76.0, 84.0, 97.0, 91.0, 100.0, 108.0, 121.0, 129.0, 137.0, 127.0, 141.0, 152.0, 147.0, 166.0, 158.0, 166.0, 159.0, 146.0, 176.0, 189.0, 213.0, 212.0, 228.0, 193.0, 232.0, 225.0, 210.0, 211.0, 229.0, 226.0, 237.0, 246.0, 243.0, 265.0, 303.0, 248.0, 302.0, 326.0, 318.0, 340.0, 362.0, 313.0, 366.0, 379.0, 376.0, 423.0, 433.0, 486.0, 486.0, 482.0, 518.0, 548.0, 583.0, 628.0, 705.0, 735.0, 814.0, 852.0, 920.0, 1000.0, 1095.0, 1184.0, 1296.0, 1544.0, 1700.0, 2091.0, 2738.0, 3794.0, 5591.0, 8640.0, 13619.0, 20171.0, 11051.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        assert h.values.tolist() == [
+            4814.0, 45.0, 45.0, 25.0, 15.0, 4.0, 0.0, 6.0, 7.0, 5.0, 3.0, 3.0,
+            6.0, 3.0, 7.0, 5.0, 7.0, 11.0, 9.0, 5.0, 4.0, 10.0, 12.0, 7.0,
+            10.0, 8.0, 12.0, 11.0, 12.0, 12.0, 14.0, 15.0, 13.0, 14.0, 14.0,
+            20.0, 20.0, 16.0, 21.0, 22.0, 22.0, 28.0, 25.0, 33.0, 26.0, 21.0,
+            42.0, 36.0, 43.0, 42.0, 43.0, 39.0, 42.0, 56.0, 67.0, 50.0, 67.0,
+            71.0, 59.0, 76.0, 73.0, 84.0, 63.0, 76.0, 84.0, 97.0, 91.0, 100.0,
+            108.0, 121.0, 129.0, 137.0, 127.0, 141.0, 152.0, 147.0, 166.0,
+            158.0, 166.0, 159.0, 146.0, 176.0, 189.0, 213.0, 212.0, 228.0,
+            193.0, 232.0, 225.0, 210.0, 211.0, 229.0, 226.0, 237.0, 246.0,
+            243.0, 265.0, 303.0, 248.0, 302.0, 326.0, 318.0, 340.0, 362.0,
+            313.0, 366.0, 379.0, 376.0, 423.0, 433.0, 486.0, 486.0, 482.0,
+            518.0, 548.0, 583.0, 628.0, 705.0, 735.0, 814.0, 852.0, 920.0,
+            1000.0, 1095.0, 1184.0, 1296.0, 1544.0, 1700.0, 2091.0, 2738.0,
+            3794.0, 5591.0, 8640.0, 13619.0, 20171.0, 11051.0, 0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+        ]
 
     def test_issue70(self):
         f = uproot.open("tests/samples/issue70.root")
@@ -128,8 +201,12 @@ class Test(unittest.TestCase):
 
     def test_issue74(self):
         t = uproot.open("tests/samples/issue74.root")["Events"]
-        assert all(isinstance(x[0], uproot_methods.classes.TVector3.Methods) for x in t.array("bees.xyzPosition"))
-        assert t.array("bees.xyzPosition")[0][0] == uproot_methods.classes.TVector3.TVector3(1.0, 2.0, -1.0)
+        assert all(
+            isinstance(x[0], uproot_methods.classes.TVector3.Methods)
+            for x in t.array("bees.xyzPosition"))
+        assert t.array("bees.xyzPosition"
+                       )[0][0] == uproot_methods.classes.TVector3.TVector3(
+                           1.0, 2.0, -1.0)
 
     def test_issue76(self):
         t = uproot.open("tests/samples/issue76.root")["Events"]
@@ -141,18 +218,21 @@ class Test(unittest.TestCase):
         t = uproot.open("tests/samples/issue79.root")["taus"]
         assert t["pt"].numbaskets == 2
         baskets = numpy.concatenate([t["pt"].basket(0), t["pt"].basket(1)])
-        assert baskets.shape == (t["pt"].numentries,)
+        assert baskets.shape == (t["pt"].numentries, )
         assert numpy.array_equal(baskets, t["pt"].array())
 
     def test_issue96(self):
         t = uproot.open("tests/samples/issue96.root")["tree"]
-        assert all(isinstance(x, uproot_methods.classes.TLorentzVector.Methods) for x in t.array("jet1P4"))
+        assert all(
+            isinstance(x, uproot_methods.classes.TLorentzVector.Methods)
+            for x in t.array("jet1P4"))
 
     def test_geant4(self):
         f = uproot.open("tests/samples/from-geant4.root")
         arrays = f["Details"].arrays()
         assert arrays[b"numgood"][0] == 224
-        assert [len(x) for x in f["HitStrips"].arrays().values()] == [4808, 4808, 4808]
+        assert [len(x) for x in f["HitStrips"].arrays().values()
+                ] == [4808, 4808, 4808]
         assert sum(f["edep_inner"].values) == 1547
         assert sum(sum(x) for x in f["recon_orig"].values) == 141
 
@@ -171,7 +251,24 @@ class Test(unittest.TestCase):
 
     def test_issue213(self):
         t = uproot.open("tests/samples/issue213.root")["T"]
-        assert t["fMCHits.fPosition"].array().x.tolist() == [[], [], [], [], [], [], [], [42.17024612426758, 50.63192367553711], [], [], [], [43.292755126953125], [], [], [], [], [], [], [], [], [42.15415954589844], [41.60139083862305], [42.95103454589844], [], [41.55511474609375], [], [], [], [], [], [], [42.549156188964844], [], [], [], [42.80044174194336, 46.136253356933594], [], [], [], [], [41.58171081542969], [], [], [42.741485595703125], [41.228477478027344], [], [], [], [], [], [], [], [], [], [42.518882751464844], [43.34626388549805], [], [], [43.214759826660156], [], [], [], [], [], [], [42.78463363647461], [], [], [], [], [], [], [], [41.927093505859375], [42.65863037109375], [], [42.66266632080078], [], [], [], [], [], [], [], [], [], [], [41.91042709350586, 41.807674407958984], [], [42.79293441772461], [], [], [], [], [], [], [41.72440719604492], [], [], [41.609615325927734]]
+        assert t["fMCHits.fPosition"].array().x.tolist() == [
+            [], [], [], [], [], [], [], [42.17024612426758, 50.63192367553711],
+            [], [], [], [43.292755126953125], [], [], [], [], [], [], [], [],
+            [42.15415954589844], [41.60139083862305], [42.95103454589844], [],
+            [41.55511474609375], [], [], [], [], [], [], [42.549156188964844],
+            [], [], [], [42.80044174194336,
+                         46.136253356933594], [], [], [], [],
+            [41.58171081542969], [], [], [42.741485595703125],
+            [41.228477478027344], [], [], [], [], [], [], [], [], [],
+            [42.518882751464844], [43.34626388549805], [], [],
+            [43.214759826660156], [], [], [], [], [], [], [42.78463363647461],
+            [], [], [], [], [], [], [], [41.927093505859375],
+            [42.65863037109375], [], [42.66266632080078], [], [], [], [], [],
+            [], [], [], [], [], [41.91042709350586,
+                                 41.807674407958984], [], [42.79293441772461],
+            [], [], [], [], [], [], [41.72440719604492], [], [],
+            [41.609615325927734]
+        ]
 
     def test_issue232(self):
         try:
@@ -180,7 +277,9 @@ class Test(unittest.TestCase):
             pass
         else:
             t = uproot.open("tests/samples/issue232.root")["fTreeV0"]
-            t.pandas.df(["V0Hyper.fNsigmaHe3Pos", "V0Hyper.fDcaPos2PrimaryVertex"], flatten=True)
+            t.pandas.df(
+                ["V0Hyper.fNsigmaHe3Pos", "V0Hyper.fDcaPos2PrimaryVertex"],
+                flatten=True)
 
     @pytest.mark.skip(reason="This one takes way too long (eospublic?).")
     def test_issue240(self):
@@ -189,7 +288,9 @@ class Test(unittest.TestCase):
         except ImportError:
             pytest.skip("unable to import pyxrootd")
         else:
-            t = uproot.open("root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root")["Events"]
+            t = uproot.open(
+                "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root"
+            )["Events"]
             assert (abs(t.array("nMuon")) < 50).all()
 
     def test_issue243(self):
@@ -213,28 +314,50 @@ class Test(unittest.TestCase):
         obj = t["DRIFT_0."].array()[0]
         assert obj._samplerName == b'DRIFT_0'
         assert obj._n == 1
-        assert obj._energy[0] == numpy.array([2.3371024], dtype=numpy.float32)[0]
+        assert obj._energy[0] == numpy.array([2.3371024],
+                                             dtype=numpy.float32)[0]
 
     def test_issue376_simple(self):
         f = uproot.open("tests/samples/from-geant4.root")
         assert type(f).classname == 'TDirectory'
         assert f.classname == 'TDirectory'
         real_class_names = ['TTree'] * 4 + ['TH1D'] * 10 + ['TH2D'] * 5
-        assert [classname_two_tuple[1] for classname_two_tuple in f.classnames()] == real_class_names
-        assert [class_two_tuple[1].classname for class_two_tuple in f.classes()] == real_class_names
+        assert [
+            classname_two_tuple[1] for classname_two_tuple in f.classnames()
+        ] == real_class_names
+        assert [
+            class_two_tuple[1].classname for class_two_tuple in f.classes()
+        ] == real_class_names
         assert [value.classname for value in f.values()] == real_class_names
 
     def test_issue376_nested(self):
         f = uproot.open("tests/samples/nesteddirs.root")
         top_level_class_names = ['TDirectory', 'TDirectory']
-        recursive_class_names = ['TDirectory', 'TDirectory', 'TTree', 'TTree', 'TDirectory', 'TTree']
-        assert [classname_two_tuple[1] for classname_two_tuple in f.classnames(recursive=False)] == top_level_class_names
-        assert [classname_two_tuple[1] for classname_two_tuple in f.classnames(recursive=True)] == recursive_class_names
-        assert [classname_two_tuple[1] for classname_two_tuple in f.allclassnames()] == recursive_class_names
+        recursive_class_names = [
+            'TDirectory', 'TDirectory', 'TTree', 'TTree', 'TDirectory', 'TTree'
+        ]
+        assert [
+            classname_two_tuple[1]
+            for classname_two_tuple in f.classnames(recursive=False)
+        ] == top_level_class_names
+        assert [
+            classname_two_tuple[1]
+            for classname_two_tuple in f.classnames(recursive=True)
+        ] == recursive_class_names
+        assert [
+            classname_two_tuple[1]
+            for classname_two_tuple in f.allclassnames()
+        ] == recursive_class_names
 
     def test_issue367(self):
         t = uproot.open("tests/samples/issue367.root")["tree"]
-        assert awkward.fromiter(t.array("weights.second"))[0].counts.tolist() == [1000, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 100, 100, 100, 1]
+        assert awkward.fromiter(
+            t.array("weights.second"))[0].counts.tolist() == [
+                1000, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,
+                10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 1000, 1000,
+                1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000,
+                100, 100, 100, 1
+            ]
 
     def test_issue390(self):
         t = uproot.open("tests/samples/issue390.root")["E"]
@@ -245,8 +368,22 @@ class Test(unittest.TestCase):
         t = uproot.open("tests/samples/issue399.root")["Event"]
         a = t["Histos.histograms1D"].array()
         for i in range(t.numentries):
-            assert [x.title for x in a[i]] == [b"Primary Hits", b"Primary Loss", b"Energy Loss", b"Primary Hits per Element", b"Primary Loss per Element", b"Energy Loss per Element"]
+            assert [x.title for x in a[i]] == [
+                b"Primary Hits", b"Primary Loss", b"Energy Loss",
+                b"Primary Hits per Element", b"Primary Loss per Element",
+                b"Energy Loss per Element"
+            ]
 
     def test_issue404(self):
         t = uproot.open("tests/samples/issue404.root")["Beam"]
-        assert t["Beam.GMAD::BeamBase.beamParticleName"].array().tolist() == [b"proton"]
+        assert t["Beam.GMAD::BeamBase.beamParticleName"].array().tolist() == [
+            b"proton"
+        ]
+
+    def test_issue124_and_followup_issue419_with_pr420(self):
+        f = uproot.open("tests/samples/issue124.root")
+        branch = f[b'KM3NET_TIMESLICE;1'][b'KM3NET_TIMESLICE']
+        assert branch.interpretation is None
+        assert 0 == branch.compressedbytes()
+        assert 0 == branch.uncompressedbytes()
+        assert 0 == branch.numbaskets

--- a/uproot/tree.py
+++ b/uproot/tree.py
@@ -987,8 +987,6 @@ class TBranchMethods(object):
 
     @property
     def numbaskets(self):
-        if self.interpretation is None:
-            return 0
         if self._recoveredbaskets is None:
             self._tryrecover()
         return self._numgoodbaskets + len(self._recoveredbaskets)
@@ -1744,7 +1742,7 @@ class TBranchMethods(object):
             with self._recoverylock:
                 self._recoveredbaskets = recoveredbaskets
                 self._entryoffsets = entryoffsets
-        else:
+        elif self.interpretation is not None:
             raise ValueError("entries in recovered baskets (offsets {0}) don't add up to total number of entries ({1})\n   in file: {2}".format(entryoffsets, self.numentries, self._context.sourcepath))
 
     def _tryrecover(self):

--- a/uproot/tree.py
+++ b/uproot/tree.py
@@ -987,6 +987,8 @@ class TBranchMethods(object):
 
     @property
     def numbaskets(self):
+        if self.interpretation is None:
+            return 0
         if self._recoveredbaskets is None:
             self._tryrecover()
         return self._numgoodbaskets + len(self._recoveredbaskets)

--- a/uproot/tree.py
+++ b/uproot/tree.py
@@ -1742,8 +1742,11 @@ class TBranchMethods(object):
             with self._recoverylock:
                 self._recoveredbaskets = recoveredbaskets
                 self._entryoffsets = entryoffsets
-        elif self.interpretation is not None:
-            raise ValueError("entries in recovered baskets (offsets {0}) don't add up to total number of entries ({1})\n   in file: {2}".format(entryoffsets, self.numentries, self._context.sourcepath))
+        else:
+            if self.interpretation is None:
+                self._recoveredbaskets = []
+            else:
+                raise ValueError("entries in recovered baskets (offsets {0}) don't add up to total number of entries ({1})\n   in file: {2}".format(entryoffsets, self.numentries, self._context.sourcepath))
 
     def _tryrecover(self):
         if self._recoveredbaskets is None:


### PR DESCRIPTION
With reference to https://github.com/scikit-hep/uproot/issues/419#issuecomment-565809752 this is a tiny patch which avoids a misleading error message when trying to call e.g. `.uncompressedbytes()` on a branch with no data (i.e. `interpretation is None`).

Not sure if you are happy with this, to me it seemed that returning 0 in the `numbaskets` `@property` should be enough to also avoid further confusions, if I understood correctly.

Anyways, at least we now have a todo entry, as you wanted @jpivarski 😉 