### PR TITLE
 Get pytest-error-for-skips from PyPI 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ install:
       conda install -c anaconda python=${PYVER} pyopenssl;
     fi
   - wget -O tests/samples/Event.root http://scikit-hep.org/uproot/examples/Event.root
-  - pip install git+https://github.com/chrisburr/pytest-error-for-skips.git@patch-1
+  - pip install pytest-error-for-skips
 
 addons:
   apt:

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -347,6 +347,7 @@ class Test(object):
             ]
 
     def test_issue390(self):
+        pytest.importorskip("pandas")
         t = uproot.open("tests/samples/issue390.root")["E"]
         t.pandas.df("hits.*")
         t.pandas.df("trks.*")


### PR DESCRIPTION
I wasn't expecting my PR to fix `pytest-error-for-skips` to be accepted as it hadn't been updated in years but it has been so we can now get it from PyPI.

Also skips `test_issue390` if `pandas` is unavailable.