### PR TITLE
Clear ChunkedSource cache on explicit close

### DIFF
--- a/uproot/source/chunked.py
+++ b/uproot/source/chunked.py
@@ -46,6 +46,10 @@ class ChunkedSource(uproot.source.source.Source):
     def _read(self, chunkindex):
         raise NotImplementedError
 
+    def close(self):
+        super(ChunkedSource, self).close()
+        self.cache.clear()
+
     def dismiss(self):
         if self._futures is not None:
             for future in self._futures.values():


### PR DESCRIPTION
For those that want to ensure on-closure (or context managers)
cleanup of the (100 MB large by default) chunk cache as early as possible,
since the source is attached to uproot objects with reference cycles and won't be cleaned
up until the next generational gc run in python, which can lead to
unnecessarily high peak memory usage.