### PR TITLE
Allow tests to be ran with minimal dependencies

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,6 +44,7 @@ install:
   - "python --version"
 
 build_script:
+  - "SET PATH=%PYTHON%;%PATH%"
   - "python -m pip install --upgrade pip"
   - "pip install %NUMPY%"
   - "pip install \"awkward>=0.12.0,<1.0\""

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,18 +41,18 @@ environment:
       NUMPY: "numpy>=1.15"
 
 install:
+  - "SET PATH=%PYTHON%;%PATH%"
   - "python --version"
 
 build_script:
-  - "SET PATH=%PYTHON%;%PATH%"
   - "python -m pip install --upgrade pip"
-  - "pip install %NUMPY%"
-  - "pip install \"awkward>=0.12.0,<1.0\""
+  - "python -m pip install %NUMPY%"
+  - "python -m pip install \"awkward>=0.12.0,<1.0\""
   - "python -c \"import awkward; print(awkward.__version__)\""
-  - "pip install \"uproot-methods>=0.7.0\""
+  - "python -m pip install \"uproot-methods>=0.7.0\""
   - "python -c \"import uproot_methods; print(uproot_methods.__version__)\""
-  - "pip install cachetools lz4 zstandard mock xxhash"
-  - "pip install -i https://pypi.anaconda.org/carlkl/simple backports.lzma"
-  - "pip install pytest pytest-runner pandas requests"
+  - "python -m pip install cachetools lz4 zstandard mock xxhash"
+  - "python -m pip install -i https://pypi.anaconda.org/carlkl/simple backports.lzma"
+  - "python -m pip install pytest pytest-runner pandas requests"
   - "curl -fsS -o tests/samples/Event.root http://scikit-hep.org/uproot/examples/Event.root"
   - "pytest -v tests"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,7 +52,7 @@ build_script:
   - "python -m pip install \"uproot-methods>=0.7.0\""
   - "python -c \"import uproot_methods; print(uproot_methods.__version__)\""
   - "python -m pip install cachetools lz4 zstandard mock xxhash"
-  - "python -m pip install -i https://pypi.anaconda.org/carlkl/simple backports.lzma"
+  - "IF \"%PYTHON_VERSION%\"==\"2.7.10\" ( python -m pip install -i https://pypi.anaconda.org/carlkl/simple backports.lzma )"
   - "python -m pip install pytest pytest-runner pandas requests"
   - "curl -fsS -o tests/samples/Event.root http://scikit-hep.org/uproot/examples/Event.root"
   - "pytest -v tests"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,4 +55,4 @@ build_script:
   - "IF \"%PYTHON_VERSION%\"==\"2.7.10\" ( python -m pip install -i https://pypi.anaconda.org/carlkl/simple backports.lzma )"
   - "python -m pip install pytest pytest-runner pandas requests"
   - "curl -fsS -o tests/samples/Event.root http://scikit-hep.org/uproot/examples/Event.root"
-  - "pytest -v tests"
+  - "python -m pytest -v tests"

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -2,7 +2,15 @@
 
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot/blob/master/LICENSE
 
+import pytest
+try:
+    import lzma
+except ImportError:
+    lzma = pytest.importorskip('backports.lzma')
+lz4 = pytest.importorskip('lz4')
+zstandard = pytest.importorskip('zstandard')
 import uproot
+
 
 class Test(object):
     def test_compression_identity(self):

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -4,7 +4,7 @@
 
 import pytest
 import mock
-from requests.exceptions import HTTPError
+HTTPError = pytest.importorskip('requests.exceptions').HTTPError
 
 import uproot
 

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -248,6 +248,7 @@ class Test(object):
         assert t.array("V0s.fEtaPos")[-3].tolist() == [-0.390625, 0.046875]
 
     def test_issue213(self):
+        pytest.importorskip("xxhash")
         t = uproot.open("tests/samples/issue213.root")["T"]
         assert t["fMCHits.fPosition"].array().x.tolist() == [
             [], [], [], [], [], [], [], [42.17024612426758, 50.63192367553711],

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -595,12 +595,13 @@ class Test(object):
     @pytest.mark.parametrize("use_http", [False, True])
     def test_hist_in_tree(self, use_http):
         if use_http:
+            pytest.importorskip("requests")
+            tree = uproot.open("http://scikit-hep.org/uproot/examples/Event.root")["T"]
+        else:
             path = os.path.join("tests", "samples", "Event.root")
             if not os.path.exists(path):
                 raise pytest.skip()
             tree = uproot.open(path)["T"]
-        else:
-            tree = uproot.open("http://scikit-hep.org/uproot/examples/Event.root")["T"]
         check = [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
                  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0,
                  1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
@@ -625,12 +626,13 @@ class Test(object):
             b'fTriggerBits.TObject'
         ]
         if use_http:
+            pytest.importorskip("requests")
+            tree = uproot.open("http://scikit-hep.org/uproot/examples/Event.root")["T"]
+        else:
             path = os.path.join("tests", "samples", "Event.root")
             if not os.path.exists(path):
                 raise pytest.skip()
             tree = uproot.open(path)["T"]
-        else:
-            tree = uproot.open("http://scikit-hep.org/uproot/examples/Event.root")["T"]
         branches_without_interp = [b.name for b in tree.allvalues() if b.interpretation is None]
         assert branches_without_interp == known_branches_without_interp
         assert tree.array("fTracks.fTArray[3]", entrystop=10)[5][10].tolist()  == [11.03951644897461, 19.40645980834961, 34.54059982299805]

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -2,13 +2,15 @@
 
 # BSD 3-Clause License; see https://github.com/scikit-hep/uproot/blob/master/LICENSE
 
+import pytest
 try:
     import lzma
 except ImportError:
-    from backports import lzma
-import lz4
+    lzma = pytest.importorskip('backports.lzma')
+lz4 = pytest.importorskip('lz4')
 
 import uproot
+
 
 class Test(object):
     sample = {

--- a/uproot/interp/auto.py
+++ b/uproot/interp/auto.py
@@ -52,9 +52,9 @@ def _ftype2dtype(fType, awkward):
     elif fType in (uproot.const.kBits, uproot.const.kUInt, uproot.const.kCounter):
         return awkward.numpy.dtype(">u4")
     elif fType == uproot.const.kLong:
-        return awkward.numpy.dtype(awkward.numpy.long).newbyteorder(">")
+        return awkward.numpy.dtype(">i8")
     elif fType == uproot.const.kULong:
-        return awkward.numpy.dtype(">u" + repr(awkward.numpy.dtype(awkward.numpy.long).itemsize))
+        return awkward.numpy.dtype(">u8")
     elif fType == uproot.const.kLong64:
         return awkward.numpy.dtype(">i8")
     elif fType == uproot.const.kULong64:


### PR DESCRIPTION
Adds more `importorskip` statements so the test suite can be ran without any of the optional dependencies (useful for the `uproot-base` package in conda-forge https://github.com/conda-forge/uproot-feedstock/pull/58).

Interestingly I see a failure with Python 3.6, 3.7 and 3.8 (but not 2.7!) on Windows which looks like it might be real ([full log](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=114956&view=logs&j=5be07ae1-d8ba-5406-47b6-8e3a3a12f825&t=0d1d4714-3221-52cd-cfdb-f62a891e036b)). Any guesses?

```
================================== FAILURES ===================================
______________________________ Test.test_issue38 ______________________________

self = <tests.test_issues.Test object at 0x000001CEBC425748>

    def test_issue38(self):
        before_hadd = uproot.open(
            "tests/samples/issue38a.root")["ntupler/tree"]
        after_hadd = uproot.open("tests/samples/issue38b.root")["ntupler/tree"]
    
        before = before_hadd.arrays()
        after = after_hadd.arrays()
    
        assert set(before.keys())
        assert set(after.keys())
    
        for key in before.keys():
>           assert before[key].tolist() * 3 == after[key].tolist()
E           assert [[0, 1, 0, 2,..., 0, 2, 0, 3]] == [[1, 2, 3], [...3], [1, 2, 3]]
E             At index 0 diff: [0, 1, 0, 2, 0, 3] != [1, 2, 3]
E             Use -v to get the full diff

tests\test_issues.py:80: AssertionError
================== 1 failed, 78 passed, 16 skipped in 10.78s ==================
```