### PR TITLE
Add "compress" extra to allow all compression libs to be easily installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -145,7 +145,8 @@ setup(name = "uproot",
       install_requires = ["numpy>=1.13.1", "awkward>=0.12.0,<1.0", "uproot-methods>=0.7.0", "cachetools"],
       setup_requires = ["pytest-runner"],
       extras_require = {
-          'testing': ["pytest>=3.9", "pkgconfig", "lz4", "zstandard", 'backports.lzma;python_version<"3.3"', "xxhash", "mock", "requests"],
+          "testing": ["pytest>=3.9", "pkgconfig", "lz4", "zstandard", 'backports.lzma;python_version<"3.3"', "xxhash", "mock", "requests"],
+          "decompression": ["lz4", "zstandard", 'backports.lzma;python_version<"3.3"', "xxhash"],
       },
       classifiers = [
           "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -146,7 +146,7 @@ setup(name = "uproot",
       setup_requires = ["pytest-runner"],
       extras_require = {
           "testing": ["pytest>=3.9", "pkgconfig", "lz4", "zstandard", 'backports.lzma;python_version<"3.3"', "xxhash", "mock", "requests"],
-          "decompression": ["lz4", "zstandard", 'backports.lzma;python_version<"3.3"', "xxhash"],
+          "compress": ["lz4", "zstandard", 'backports.lzma;python_version<"3.3"', "xxhash"],
       },
       classifiers = [
           "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
I recently modified LHCb's [DIRAC](https://github.com/DIRACGrid/DIRAC/#dirac) extension to make it use `uproot` for extracting metadata from ROOT files. This has worked really well but declaring the dependency is a little awkward as it has to list each compression library individually and stay updated if new ones are ever added.

What do you think about adding another extra that allows people to depend on all of the decompression related dependencies using `pip install uproot[decompress]` or adding `uproot[decompress]` to their package's `setup.py`?

Alternative name suggestions for this extra are welcome.