### PR TITLE
[WIP] Try to fix #465 again; this time focusing on the interpretation.

### DIFF
--- a/uproot/version.py
+++ b/uproot/version.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 
 import re
 
-__version__ = "3.11.3"
+__version__ = "3.11.4"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
See https://github.com/scikit-hep/uproot/pull/466#issuecomment-600154112

The previous PR was based on a mistaken understanding of the problem. The real error is in `TTree::_attachstreamers` (maybe we descended the streamers incorrectly and assigned the wrong level node?) or maybe `uproot.interp.auto.interpret` (the massive function that assigns interpretations from what metadata it finds).