### PR TITLE
Add support to write Jagged Arrays to TTrees

### DIFF
--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -7,6 +7,8 @@ from os.path import join
 import pytest
 import numpy
 
+import awkward
+
 import uproot
 from uproot.write.objects.TTree import newtree, newbranch
 
@@ -1855,3 +1857,195 @@ def test_tree_threedim(tmp_path):
         for j in range(3):
             for k in range(4):
                 assert a[i][j][k] == test[j][k]
+
+def test_jagged_i4(tmp_path):
+    filename = join(str(tmp_path), "example.root")
+
+    a = awkward.fromiter([[0],
+                          [1, 2]])
+
+    with uproot.recreate(filename, compression=None) as f:
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i4"), awkward=True)})
+        f["t"].extend({"branch": a})
+
+    f = ROOT.TFile.Open(filename)
+    tree = f.Get("t")
+    for i, event in enumerate(tree):
+        assert(numpy.all([x for x in event.branch] == a[i]))
+
+def test_jagged_uproot_i4(tmp_path):
+    filename = join(str(tmp_path), "example.root")
+
+    a = awkward.fromiter([[0],
+                          [1, 2],
+                          [10, 11, 12]])
+
+    with uproot.recreate(filename, compression=None) as f:
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i4"), awkward=True)})
+        f["t"].extend({"branch": a})
+
+    f = uproot.open(filename)
+    array = f["t"].array(["branch"])
+    for i in range(len(array)):
+        for j in range(len(array[i])):
+            assert(array[i][j] == a[i][j])
+
+def test_jagged_i8(tmp_path):
+    filename = join(str(tmp_path), "example.root")
+
+    a = awkward.fromiter([[0],
+                          [1, 2]])
+
+    with uproot.recreate(filename, compression=None) as f:
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i8"), awkward=True)})
+        f["t"].extend({"branch": a})
+
+    f = ROOT.TFile.Open(filename)
+    tree = f.Get("t")
+    for i, event in enumerate(tree):
+        assert(numpy.all([x for x in event.branch] == a[i]))
+
+def test_jagged_uproot_i8(tmp_path):
+    filename = join(str(tmp_path), "example.root")
+
+    a = awkward.fromiter([[0],
+                          [1, 2],
+                          [10, 11, 12]])
+
+    with uproot.recreate(filename, compression=None) as f:
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i8"), awkward=True)})
+        f["t"].extend({"branch": a})
+
+    f = uproot.open(filename)
+    array = f["t"].array(["branch"])
+    for i in range(len(array)):
+        for j in range(len(array[i])):
+            assert(array[i][j] == a[i][j])
+
+def test_jagged_int8(tmp_path):
+    filename = join(str(tmp_path), "example.root")
+
+    a = awkward.fromiter([[0],
+                          [1, 2]])
+
+    with uproot.recreate(filename, compression=None) as f:
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype("int8"), awkward=True)})
+        f["t"].extend({"branch": a})
+
+    f = ROOT.TFile.Open(filename)
+    tree = f.Get("t")
+    for i, event in enumerate(tree):
+        assert(numpy.all([x for x in event.branch] == a[i]))
+
+def test_jagged_uproot_int8(tmp_path):
+    filename = join(str(tmp_path), "example.root")
+
+    a = awkward.fromiter([[0],
+                          [1, 2],
+                          [10, 11, 12]])
+
+    with uproot.recreate(filename, compression=None) as f:
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype("int8"), awkward=True)})
+        f["t"].extend({"branch": a})
+
+    f = uproot.open(filename)
+    array = f["t"].array(["branch"])
+    for i in range(len(array)):
+        for j in range(len(array[i])):
+            assert(array[i][j] == a[i][j])
+
+def test_jagged_f8(tmp_path):
+    filename = join(str(tmp_path), "example.root")
+
+    a = awkward.fromiter([[0],
+                          [1, 2]])
+
+    with uproot.recreate(filename, compression=None) as f:
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">f8"), awkward=True)})
+        f["t"].extend({"branch": a})
+
+    f = ROOT.TFile.Open(filename)
+    tree = f.Get("t")
+    for i, event in enumerate(tree):
+        assert(numpy.all([x for x in event.branch] == a[i]))
+
+def test_jagged_uproot_f8(tmp_path):
+    filename = join(str(tmp_path), "example.root")
+
+    a = awkward.fromiter([[0],
+                          [1, 2],
+                          [10, 11, 12]])
+
+    with uproot.recreate(filename, compression=None) as f:
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">f8"), awkward=True)})
+        f["t"].extend({"branch": a})
+
+    f = uproot.open(filename)
+    array = f["t"].array(["branch"])
+    for i in range(len(array)):
+        for j in range(len(array[i])):
+            assert(array[i][j] == a[i][j])
+
+def test_jagged_f4(tmp_path):
+    filename = join(str(tmp_path), "example.root")
+
+    a = awkward.fromiter([[0],
+                          [1, 2]])
+
+    with uproot.recreate(filename, compression=None) as f:
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">f4"), awkward=True)})
+        f["t"].extend({"branch": a})
+
+    f = ROOT.TFile.Open(filename)
+    tree = f.Get("t")
+    for i, event in enumerate(tree):
+        assert(numpy.all([x for x in event.branch] == a[i]))
+
+def test_jagged_uproot_f4(tmp_path):
+    filename = join(str(tmp_path), "example.root")
+
+    a = awkward.fromiter([[0],
+                          [1, 2],
+                          [10, 11, 12]])
+
+    with uproot.recreate(filename, compression=None) as f:
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">f4"), awkward=True)})
+        f["t"].extend({"branch": a})
+
+    f = uproot.open(filename)
+    array = f["t"].array(["branch"])
+    for i in range(len(array)):
+        for j in range(len(array[i])):
+            assert(array[i][j] == a[i][j])
+
+def test_jagged_i2(tmp_path):
+    filename = join(str(tmp_path), "example.root")
+
+    a = awkward.fromiter([[0],
+                          [1, 2]])
+
+    with uproot.recreate(filename, compression=None) as f:
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i2"), awkward=True)})
+        f["t"].extend({"branch": a})
+
+    f = ROOT.TFile.Open(filename)
+    tree = f.Get("t")
+    for i, event in enumerate(tree):
+        assert(numpy.all([x for x in event.branch] == a[i]))
+
+def test_jagged_uproot_i2(tmp_path):
+    filename = join(str(tmp_path), "example.root")
+
+    a = awkward.fromiter([[0],
+                          [1, 2],
+                          [10, 11, 12]])
+
+    with uproot.recreate(filename, compression=None) as f:
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i2"), awkward=True)})
+        f["t"].extend({"branch": a})
+
+    f = uproot.open(filename)
+    array = f["t"].array(["branch"])
+    for i in range(len(array)):
+        for j in range(len(array[i])):
+            assert(array[i][j] == a[i][j])

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -2050,3 +2050,89 @@ def test_jagged_uproot_i2(tmp_path):
     for i in range(len(array)):
         for j in range(len(array[i])):
             assert(array[i][j] == a[i][j])
+
+def test_jagged_i2_multiple_sametype(tmp_path):
+    filename = join(str(tmp_path), "example.root")
+
+    a = awkward.fromiter([[0],
+                          [1, 2]])
+
+    b = awkward.fromiter([[3],
+                          [7, 12]])
+
+    with uproot.recreate(filename, compression=None) as f:
+        f["t"] = uproot.newtree({"branch1": uproot.newbranch(numpy.dtype(">i2"), awkward=True),
+                                 "branch2": uproot.newbranch(numpy.dtype(">i2"), awkward=True)})
+        f["t"].extend({"branch1": a,
+                       "branch2": b})
+
+    f = ROOT.TFile.Open(filename)
+    tree = f.Get("t")
+    for i, event in enumerate(tree):
+        assert(numpy.all([x for x in event.branch1] == a[i]))
+        assert(numpy.all([x for x in event.branch2] == b[i]))
+
+def test_jagged_multiple_difftype(tmp_path):
+    filename = join(str(tmp_path), "example.root")
+
+    a = awkward.fromiter([[0],
+                          [1, 2]])
+
+    b = awkward.fromiter([[3],
+                          [7, 12]])
+
+    with uproot.recreate(filename, compression=None) as f:
+        f["t"] = uproot.newtree({"branch1": uproot.newbranch(numpy.dtype(">i2"), awkward=True),
+                                 "branch2": uproot.newbranch(numpy.dtype(">i4"), awkward=True)})
+        f["t"].extend({"branch1": a,
+                       "branch2": b})
+
+    f = ROOT.TFile.Open(filename)
+    tree = f.Get("t")
+    for i, event in enumerate(tree):
+        assert(numpy.all([x for x in event.branch1] == a[i]))
+        assert(numpy.all([x for x in event.branch2] == b[i]))
+
+def test_jagged_i2_multiple_difflen(tmp_path):
+    filename = join(str(tmp_path), "example.root")
+
+    a = awkward.fromiter([[0],
+                          [1, 2]])
+
+    b = awkward.fromiter([[3],
+                          [10, 11, 12]])
+
+    with uproot.recreate(filename, compression=None) as f:
+        f["t"] = uproot.newtree({"branch1": uproot.newbranch(numpy.dtype(">i2"), awkward=True),
+                                 "branch2": uproot.newbranch(numpy.dtype(">i2"), awkward=True)})
+        f["t"].extend({"branch1": a,
+                       "branch2": b})
+
+    f = ROOT.TFile.Open(filename)
+    tree = f.Get("t")
+    for i, event in enumerate(tree):
+        assert(numpy.all([x for x in event.branch1] == a[i]))
+        assert(numpy.all([x for x in event.branch2] == b[i]))
+
+@pytest.mark.skip(reason="NotImplemented")
+def test_jagged_i2_multiple_diffshape(tmp_path):
+    filename = join(str(tmp_path), "example.root")
+
+    a = awkward.fromiter([[0],
+                          [1, 2]])
+
+    b = awkward.fromiter([[3],
+                          [7, 12],
+                          [10,11]])
+
+    with uproot.recreate(filename, compression=None) as f:
+        f["t"] = uproot.newtree({"branch1": uproot.newbranch(numpy.dtype(">i2"), awkward=True),
+                                 "branch2": uproot.newbranch(numpy.dtype(">i2"), awkward=True)})
+        f["t"].extend({"branch1": a,
+                       "branch2": b})
+
+    f = ROOT.TFile.Open(filename)
+    tree = f.Get("t")
+    for i, event in enumerate(tree):
+        assert(numpy.all([x for x in event.branch1] == a[i]))
+        assert(numpy.all([x for x in event.branch2] == b[i]))

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -2124,25 +2124,26 @@ def test_jagged_i2_multiple_difflen(tmp_path):
         assert(numpy.all([x for x in event.branch1] == a[i]))
         assert(numpy.all([x for x in event.branch2] == b[i]))
 
-@pytest.mark.skip(reason="NotImplemented")
-def test_jagged_i2_multiple_diffshape(tmp_path):
+def test_jagged_i4_manybasket(tmp_path):
     filename = join(str(tmp_path), "example.root")
 
     a = awkward.fromiter([[0],
-                          [1, 2]])
-
-    b = awkward.fromiter([[3],
-                          [7, 12],
-                          [10,11]])
+                          [1, 2],
+                          [10, 11, 12]])
+    b = awkward.fromiter([[10],
+                          [11, 12]])
+    tester = awkward.fromiter([[0],
+                               [1, 2],
+                               [10, 11, 12],
+                               [10],
+                               [11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch1": uproot.newbranch(numpy.dtype(">i2"), awkward=True),
-                                 "branch2": uproot.newbranch(numpy.dtype(">i2"), awkward=True)})
-        f["t"].extend({"branch1": a,
-                       "branch2": b})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i4"), dependence="n")})
+        f["t"].extend({"branch": a, "n": [1, 2, 3]})
+        f["t"].extend({"branch": b, "n": [1, 2]})
 
     f = ROOT.TFile.Open(filename)
     tree = f.Get("t")
     for i, event in enumerate(tree):
-        assert(numpy.all([x for x in event.branch1] == a[i]))
-        assert(numpy.all([x for x in event.branch2] == b[i]))
+        assert(numpy.all([x for x in event.branch] == tester[i]))

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -1924,40 +1924,6 @@ def test_jagged_uproot_i8(tmp_path):
         for j in range(len(array[i])):
             assert(array[i][j] == a[i][j])
 
-@pytest.mark.skip(reason="Have to fix")
-def test_jagged_int8(tmp_path):
-    filename = join(str(tmp_path), "example.root")
-
-    a = awkward.fromiter([[0],
-                          [1, 2],
-                          [10, 11, 12]])
-
-    with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype("int8"), dependence="n")})
-        f["t"].extend({"branch": a, "n": [1, 2, 3]})
-
-    f = ROOT.TFile.Open(filename)
-    tree = f.Get("t")
-    for i, event in enumerate(tree):
-        assert(numpy.all([x for x in event.branch] == a[i]))
-
-def test_jagged_uproot_int8(tmp_path):
-    filename = join(str(tmp_path), "example.root")
-
-    a = awkward.fromiter([[0],
-                          [1, 2],
-                          [10, 11, 12]])
-
-    with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype("int8"), dependence="n")})
-        f["t"].extend({"branch": a, "n": [1, 2, 3]})
-
-    f = uproot.open(filename)
-    array = f["t"].array(["branch"])
-    for i in range(len(array)):
-        for j in range(len(array[i])):
-            assert(array[i][j] == a[i][j])
-
 def test_jagged_f8(tmp_path):
     filename = join(str(tmp_path), "example.root")
 

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -1922,6 +1922,7 @@ def test_jagged_uproot_i8(tmp_path):
         for j in range(len(array[i])):
             assert(array[i][j] == a[i][j])
 
+@pytest.mark.skip(reason="Have to fix")
 def test_jagged_int8(tmp_path):
     filename = join(str(tmp_path), "example.root")
 

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -1862,11 +1862,12 @@ def test_jagged_i4(tmp_path):
     filename = join(str(tmp_path), "example.root")
 
     a = awkward.fromiter([[0],
-                          [1, 2]])
+                          [1, 2],
+                          [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i4"), awkward=True)})
-        f["t"].extend({"branch": a})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i4"), dependence="n")})
+        f["t"].extend({"branch": a, "n": [1, 2, 3]})
 
     f = ROOT.TFile.Open(filename)
     tree = f.Get("t")
@@ -1881,8 +1882,8 @@ def test_jagged_uproot_i4(tmp_path):
                           [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i4"), awkward=True)})
-        f["t"].extend({"branch": a})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i4"), dependence="n")})
+        f["t"].extend({"branch": a, "n": [1, 2, 3]})
 
     f = uproot.open(filename)
     array = f["t"].array(["branch"])
@@ -1894,11 +1895,12 @@ def test_jagged_i8(tmp_path):
     filename = join(str(tmp_path), "example.root")
 
     a = awkward.fromiter([[0],
-                          [1, 2]])
+                          [1, 2],
+                          [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i8"), awkward=True)})
-        f["t"].extend({"branch": a})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i8"), dependence="n")})
+        f["t"].extend({"branch": a, "n": [1, 2, 3]})
 
     f = ROOT.TFile.Open(filename)
     tree = f.Get("t")
@@ -1913,8 +1915,8 @@ def test_jagged_uproot_i8(tmp_path):
                           [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i8"), awkward=True)})
-        f["t"].extend({"branch": a})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i8"), dependence="n")})
+        f["t"].extend({"branch": a, "n": [1, 2, 3]})
 
     f = uproot.open(filename)
     array = f["t"].array(["branch"])
@@ -1927,11 +1929,12 @@ def test_jagged_int8(tmp_path):
     filename = join(str(tmp_path), "example.root")
 
     a = awkward.fromiter([[0],
-                          [1, 2]])
+                          [1, 2],
+                          [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype("int8"), awkward=True)})
-        f["t"].extend({"branch": a})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype("int8"), dependence="n")})
+        f["t"].extend({"branch": a, "n": [1, 2, 3]})
 
     f = ROOT.TFile.Open(filename)
     tree = f.Get("t")
@@ -1946,8 +1949,8 @@ def test_jagged_uproot_int8(tmp_path):
                           [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype("int8"), awkward=True)})
-        f["t"].extend({"branch": a})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype("int8"), dependence="n")})
+        f["t"].extend({"branch": a, "n": [1, 2, 3]})
 
     f = uproot.open(filename)
     array = f["t"].array(["branch"])
@@ -1959,11 +1962,12 @@ def test_jagged_f8(tmp_path):
     filename = join(str(tmp_path), "example.root")
 
     a = awkward.fromiter([[0],
-                          [1, 2]])
+                          [1, 2],
+                          [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">f8"), awkward=True)})
-        f["t"].extend({"branch": a})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">f8"), dependence="n")})
+        f["t"].extend({"branch": a, "n": [1, 2, 3]})
 
     f = ROOT.TFile.Open(filename)
     tree = f.Get("t")
@@ -1978,8 +1982,8 @@ def test_jagged_uproot_f8(tmp_path):
                           [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">f8"), awkward=True)})
-        f["t"].extend({"branch": a})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">f8"), dependence="n")})
+        f["t"].extend({"branch": a, "n": [1, 2, 3]})
 
     f = uproot.open(filename)
     array = f["t"].array(["branch"])
@@ -1991,11 +1995,12 @@ def test_jagged_f4(tmp_path):
     filename = join(str(tmp_path), "example.root")
 
     a = awkward.fromiter([[0],
-                          [1, 2]])
+                          [1, 2],
+                          [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">f4"), awkward=True)})
-        f["t"].extend({"branch": a})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">f4"), dependence="n")})
+        f["t"].extend({"branch": a, "n": [1, 2, 3]})
 
     f = ROOT.TFile.Open(filename)
     tree = f.Get("t")
@@ -2010,8 +2015,8 @@ def test_jagged_uproot_f4(tmp_path):
                           [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">f4"), awkward=True)})
-        f["t"].extend({"branch": a})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">f4"), dependence="n")})
+        f["t"].extend({"branch": a, "n": [1, 2, 3]})
 
     f = uproot.open(filename)
     array = f["t"].array(["branch"])
@@ -2023,11 +2028,12 @@ def test_jagged_i2(tmp_path):
     filename = join(str(tmp_path), "example.root")
 
     a = awkward.fromiter([[0],
-                          [1, 2]])
+                          [1, 2],
+                          [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i2"), awkward=True)})
-        f["t"].extend({"branch": a})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i2"), dependence="n")})
+        f["t"].extend({"branch": a, "n": [1, 2, 3]})
 
     f = ROOT.TFile.Open(filename)
     tree = f.Get("t")
@@ -2042,8 +2048,8 @@ def test_jagged_uproot_i2(tmp_path):
                           [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i2"), awkward=True)})
-        f["t"].extend({"branch": a})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i2"), dependence="n")})
+        f["t"].extend({"branch": a, "n": [1, 2, 3]})
 
     f = uproot.open(filename)
     array = f["t"].array(["branch"])
@@ -2061,10 +2067,11 @@ def test_jagged_i2_multiple_sametype(tmp_path):
                           [7, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch1": uproot.newbranch(numpy.dtype(">i2"), awkward=True),
-                                 "branch2": uproot.newbranch(numpy.dtype(">i2"), awkward=True)})
+        f["t"] = uproot.newtree({"branch1": uproot.newbranch(numpy.dtype(">i2"), dependence="n"),
+                                 "branch2": uproot.newbranch(numpy.dtype(">i2"), dependence="n")})
         f["t"].extend({"branch1": a,
-                       "branch2": b})
+                       "branch2": b,
+                       "n": [1, 2]})
 
     f = ROOT.TFile.Open(filename)
     tree = f.Get("t")
@@ -2082,10 +2089,11 @@ def test_jagged_multiple_difftype(tmp_path):
                           [7, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch1": uproot.newbranch(numpy.dtype(">i2"), awkward=True),
-                                 "branch2": uproot.newbranch(numpy.dtype(">i4"), awkward=True)})
+        f["t"] = uproot.newtree({"branch1": uproot.newbranch(numpy.dtype(">i2"), dependence="n"),
+                                 "branch2": uproot.newbranch(numpy.dtype(">i4"), dependence="n")})
         f["t"].extend({"branch1": a,
-                       "branch2": b})
+                       "branch2": b,
+                       "n": [1, 2]})
 
     f = ROOT.TFile.Open(filename)
     tree = f.Get("t")
@@ -2103,10 +2111,12 @@ def test_jagged_i2_multiple_difflen(tmp_path):
                           [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch1": uproot.newbranch(numpy.dtype(">i2"), awkward=True),
-                                 "branch2": uproot.newbranch(numpy.dtype(">i2"), awkward=True)})
+        f["t"] = uproot.newtree({"branch1": uproot.newbranch(numpy.dtype(">i2"), dependence="n1"),
+                                 "branch2": uproot.newbranch(numpy.dtype(">i2"), dependence="n2")})
         f["t"].extend({"branch1": a,
-                       "branch2": b})
+                       "n1": [1, 2],
+                       "branch2": b,
+                       "n2": [1, 3]})
 
     f = ROOT.TFile.Open(filename)
     tree = f.Get("t")

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -1867,7 +1867,7 @@ def test_jagged_i4(tmp_path):
                           [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i4"), dependence="n")})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i4"), counter="n")})
         f["t"].extend({"branch": a, "n": [1, 2, 3]})
 
     f = ROOT.TFile.Open(filename)
@@ -1883,7 +1883,7 @@ def test_jagged_uproot_i4(tmp_path):
                           [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i4"), dependence="n")})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i4"), counter="n")})
         f["t"].extend({"branch": a, "n": [1, 2, 3]})
 
     f = uproot.open(filename)
@@ -1901,7 +1901,7 @@ def test_jagged_i8(tmp_path):
                           [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i8"), dependence="n")})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i8"), counter="n")})
         f["t"].extend({"branch": a, "n": [1, 2, 3]})
 
     ROOT.gInterpreter.Declare("""
@@ -1936,7 +1936,7 @@ def test_jagged_uproot_i8(tmp_path):
                           [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i8"), dependence="n")})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i8"), counter="n")})
         f["t"].extend({"branch": a, "n": [1, 2, 3]})
 
     f = uproot.open(filename)
@@ -1953,7 +1953,7 @@ def test_jagged_f8(tmp_path):
                           [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">f8"), dependence="n")})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">f8"), counter="n")})
         f["t"].extend({"branch": a, "n": [1, 2, 3]})
 
     f = ROOT.TFile.Open(filename)
@@ -1969,7 +1969,7 @@ def test_jagged_uproot_f8(tmp_path):
                           [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">f8"), dependence="n")})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">f8"), counter="n")})
         f["t"].extend({"branch": a, "n": [1, 2, 3]})
 
     f = uproot.open(filename)
@@ -1986,7 +1986,7 @@ def test_jagged_f4(tmp_path):
                           [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">f4"), dependence="n")})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">f4"), counter="n")})
         f["t"].extend({"branch": a, "n": [1, 2, 3]})
 
     f = ROOT.TFile.Open(filename)
@@ -2002,7 +2002,7 @@ def test_jagged_uproot_f4(tmp_path):
                           [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">f4"), dependence="n")})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">f4"), counter="n")})
         f["t"].extend({"branch": a, "n": [1, 2, 3]})
 
     f = uproot.open(filename)
@@ -2019,7 +2019,7 @@ def test_jagged_i2(tmp_path):
                           [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i2"), dependence="n")})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i2"), counter="n")})
         f["t"].extend({"branch": a, "n": [1, 2, 3]})
 
     f = ROOT.TFile.Open(filename)
@@ -2035,7 +2035,7 @@ def test_jagged_uproot_i2(tmp_path):
                           [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i2"), dependence="n")})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i2"), counter="n")})
         f["t"].extend({"branch": a, "n": [1, 2, 3]})
 
     f = uproot.open(filename)
@@ -2054,8 +2054,8 @@ def test_jagged_i2_multiple_sametype(tmp_path):
                           [7, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch1": uproot.newbranch(numpy.dtype(">i2"), dependence="n"),
-                                 "branch2": uproot.newbranch(numpy.dtype(">i2"), dependence="n")})
+        f["t"] = uproot.newtree({"branch1": uproot.newbranch(numpy.dtype(">i2"), counter="n"),
+                                 "branch2": uproot.newbranch(numpy.dtype(">i2"), counter="n")})
         f["t"].extend({"branch1": a,
                        "branch2": b,
                        "n": [1, 2]})
@@ -2076,8 +2076,8 @@ def test_jagged_multiple_difftype(tmp_path):
                           [7, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch1": uproot.newbranch(numpy.dtype(">i2"), dependence="n"),
-                                 "branch2": uproot.newbranch(numpy.dtype(">i4"), dependence="n")})
+        f["t"] = uproot.newtree({"branch1": uproot.newbranch(numpy.dtype(">i2"), counter="n"),
+                                 "branch2": uproot.newbranch(numpy.dtype(">i4"), counter="n")})
         f["t"].extend({"branch1": a,
                        "branch2": b,
                        "n": [1, 2]})
@@ -2098,8 +2098,8 @@ def test_jagged_i2_multiple_difflen(tmp_path):
                           [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch1": uproot.newbranch(numpy.dtype(">i2"), dependence="n1"),
-                                 "branch2": uproot.newbranch(numpy.dtype(">i2"), dependence="n2")})
+        f["t"] = uproot.newtree({"branch1": uproot.newbranch(numpy.dtype(">i2"), counter="n1"),
+                                 "branch2": uproot.newbranch(numpy.dtype(">i2"), counter="n2")})
         f["t"].extend({"branch1": a,
                        "n1": [1, 2],
                        "branch2": b,
@@ -2126,7 +2126,7 @@ def test_jagged_i4_manybasket(tmp_path):
                                [11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i4"), dependence="n")})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i4"), counter="n")})
         f["t"].extend({"branch": a, "n": [1, 2, 3]})
         f["t"].extend({"branch": b, "n": [1, 2]})
 

--- a/uproot/write/TKey.py
+++ b/uproot/write/TKey.py
@@ -25,6 +25,8 @@ class BasketKey(object):
         self.fNevBuf = fNevBuf
         self.fNevBufSize = fNevBufSize
 
+        self.old_fLast = 0
+
     @property
     def fKeylen(self):
         return self._format1.size + uproot.write.sink.cursor.Cursor.length_strings([self.fClassName, self.fName, self.fTitle]) + self._format_basketkey.size + 1
@@ -36,7 +38,7 @@ class BasketKey(object):
     def update(self):
         self.cursor.update_fields(self.sink, self._format1, self.fNbytes, self._version, self.fObjlen, self.fDatime, self.fKeylen, self.fCycle, self.fSeekKey, self.fSeekPdir)
 
-    def write(self, cursor, sink):
+    def write(self, cursor, sink, awkward=False):
         self.cursor = uproot.write.sink.cursor.Cursor(cursor.index)
         self.sink = sink
 
@@ -48,7 +50,13 @@ class BasketKey(object):
         cursor.write_string(sink, self.fTitle)
 
         basketversion = 3
-        cursor.write_fields(sink, self._format_basketkey, basketversion, self.fBufferSize, self.fNevBufSize, self.fNevBuf, self.fLast)
+        if awkward:
+            if self.old_fLast == 0:
+                raise Exception("awkward flag should be False")
+            cursor.write_fields(sink, self._format_basketkey, basketversion, self.fBufferSize, self.fNevBufSize, self.fNevBuf, self.old_fLast)
+        else:
+            cursor.write_fields(sink, self._format_basketkey, basketversion, self.fBufferSize, self.fNevBufSize, self.fNevBuf, self.fLast)
+            self.old_fLast = self.fLast
         cursor.write_data(sink, b"\x00")
 
     _version = 1004
@@ -75,7 +83,9 @@ class TKey(object):
     def update(self):
         self.cursor.update_fields(self.sink, self._format1, self.fNbytes, self._version, self.fObjlen, self.fDatime, self.fKeylen, self.fCycle, self.fSeekKey, self.fSeekPdir)
 
-    def write(self, cursor, sink):
+    def write(self, cursor, sink, awkward=False):
+        if awkward:
+            raise Exception("awkward flag should be False")
         self.cursor = uproot.write.sink.cursor.Cursor(cursor.index)
         self.sink = sink
 

--- a/uproot/write/TKey.py
+++ b/uproot/write/TKey.py
@@ -38,7 +38,7 @@ class BasketKey(object):
     def update(self):
         self.cursor.update_fields(self.sink, self._format1, self.fNbytes, self._version, self.fObjlen, self.fDatime, self.fKeylen, self.fCycle, self.fSeekKey, self.fSeekPdir)
 
-    def write(self, cursor, sink, awkward=False):
+    def write(self, cursor, sink, isjagged=False):
         self.cursor = uproot.write.sink.cursor.Cursor(cursor.index)
         self.sink = sink
 
@@ -50,9 +50,9 @@ class BasketKey(object):
         cursor.write_string(sink, self.fTitle)
 
         basketversion = 3
-        if awkward:
+        if isjagged:
             if self.old_fLast == 0:
-                raise Exception("awkward flag should be False")
+                raise Exception("isjagged flag should be False")
             cursor.write_fields(sink, self._format_basketkey, basketversion, self.fBufferSize, self.fNevBufSize, self.fNevBuf, self.old_fLast)
         else:
             cursor.write_fields(sink, self._format_basketkey, basketversion, self.fBufferSize, self.fNevBufSize, self.fNevBuf, self.fLast)
@@ -83,9 +83,9 @@ class TKey(object):
     def update(self):
         self.cursor.update_fields(self.sink, self._format1, self.fNbytes, self._version, self.fObjlen, self.fDatime, self.fKeylen, self.fCycle, self.fSeekKey, self.fSeekPdir)
 
-    def write(self, cursor, sink, awkward=False):
-        if awkward:
-            raise Exception("awkward flag should be False")
+    def write(self, cursor, sink, isjagged=False):
+        if isjagged:
+            raise Exception("isjagged flag should be False")
         self.cursor = uproot.write.sink.cursor.Cursor(cursor.index)
         self.sink = sink
 

--- a/uproot/write/compress.py
+++ b/uproot/write/compress.py
@@ -53,7 +53,7 @@ algo = {uproot.const.kZLIB: ZLIB,
         uproot.const.kLZMA: LZMA,
         uproot.const.kLZ4: LZ4}
 
-def write(context, cursor, givenbytes, compression, key, keycursor):
+def write(context, cursor, givenbytes, compression, key, keycursor, awkward=False):
     retaincursor = copy.copy(keycursor)
     if compression is None:
         algorithm, level = 0, 0
@@ -64,9 +64,12 @@ def write(context, cursor, givenbytes, compression, key, keycursor):
     uncompressedbytes = len(givenbytes)
 
     if algorithm == 0 or level == 0:
-        key.fObjlen = uncompressedbytes
+        if awkward:
+            key.fObjlen += uncompressedbytes
+        else:
+            key.fObjlen = uncompressedbytes
         key.fNbytes = key.fObjlen + key.fKeylen
-        key.write(keycursor, context._sink)
+        key.write(keycursor, context._sink, awkward)
         cursor.write_data(context._sink, givenbytes)
         return
 
@@ -94,10 +97,10 @@ def write(context, cursor, givenbytes, compression, key, keycursor):
             cursor.write_fields(context._sink, _header, algo, method, c1, c2, c3, u1, u2, u3)
             cursor.write_data(context._sink, after_compressed)
             key.fNbytes += compressedbytes + 9
-            key.write(keycursor, context._sink)
+            key.write(keycursor, context._sink, awkward)
         else:
             key.fNbytes += uncompressedbytes
-            key.write(keycursor, context._sink)
+            key.write(keycursor, context._sink, awkward)
             cursor.write_data(context._sink, givenbytes)
 
     elif algorithm == uproot.const.kLZ4:
@@ -125,10 +128,10 @@ def write(context, cursor, givenbytes, compression, key, keycursor):
             cursor.write_data(context._sink, checksum)
             cursor.write_data(context._sink, after_compressed)
             key.fNbytes += compressedbytes + 9
-            key.write(keycursor, context._sink)
+            key.write(keycursor, context._sink, awkward)
         else:
             key.fNbytes += uncompressedbytes
-            key.write(keycursor, context._sink)
+            key.write(keycursor, context._sink, awkward)
             cursor.write_data(context._sink, givenbytes)
 
     elif algorithm == uproot.const.kLZMA:
@@ -151,10 +154,10 @@ def write(context, cursor, givenbytes, compression, key, keycursor):
             cursor.write_fields(context._sink, _header, algo, method, c1, c2, c3, u1, u2, u3)
             cursor.write_data(context._sink, after_compressed)
             key.fNbytes += compressedbytes + 9
-            key.write(keycursor, context._sink)
+            key.write(keycursor, context._sink, awkward)
         else:
             key.fNbytes += uncompressedbytes
-            key.write(keycursor, context._sink)
+            key.write(keycursor, context._sink, awkward)
             cursor.write_data(context._sink, givenbytes)
 
     elif algorithm == uproot.const.kOldCompressionAlgo:

--- a/uproot/write/compress.py
+++ b/uproot/write/compress.py
@@ -53,7 +53,7 @@ algo = {uproot.const.kZLIB: ZLIB,
         uproot.const.kLZMA: LZMA,
         uproot.const.kLZ4: LZ4}
 
-def write(context, cursor, givenbytes, compression, key, keycursor, awkward=False):
+def write(context, cursor, givenbytes, compression, key, keycursor, isjagged=False):
     retaincursor = copy.copy(keycursor)
     if compression is None:
         algorithm, level = 0, 0
@@ -64,12 +64,12 @@ def write(context, cursor, givenbytes, compression, key, keycursor, awkward=Fals
     uncompressedbytes = len(givenbytes)
 
     if algorithm == 0 or level == 0:
-        if awkward:
+        if isjagged:
             key.fObjlen += uncompressedbytes
         else:
             key.fObjlen = uncompressedbytes
         key.fNbytes = key.fObjlen + key.fKeylen
-        key.write(keycursor, context._sink, awkward)
+        key.write(keycursor, context._sink, isjagged)
         cursor.write_data(context._sink, givenbytes)
         return
 
@@ -97,10 +97,10 @@ def write(context, cursor, givenbytes, compression, key, keycursor, awkward=Fals
             cursor.write_fields(context._sink, _header, algo, method, c1, c2, c3, u1, u2, u3)
             cursor.write_data(context._sink, after_compressed)
             key.fNbytes += compressedbytes + 9
-            key.write(keycursor, context._sink, awkward)
+            key.write(keycursor, context._sink, isjagged)
         else:
             key.fNbytes += uncompressedbytes
-            key.write(keycursor, context._sink, awkward)
+            key.write(keycursor, context._sink, isjagged)
             cursor.write_data(context._sink, givenbytes)
 
     elif algorithm == uproot.const.kLZ4:
@@ -128,10 +128,10 @@ def write(context, cursor, givenbytes, compression, key, keycursor, awkward=Fals
             cursor.write_data(context._sink, checksum)
             cursor.write_data(context._sink, after_compressed)
             key.fNbytes += compressedbytes + 9
-            key.write(keycursor, context._sink, awkward)
+            key.write(keycursor, context._sink, isjagged)
         else:
             key.fNbytes += uncompressedbytes
-            key.write(keycursor, context._sink, awkward)
+            key.write(keycursor, context._sink, isjagged)
             cursor.write_data(context._sink, givenbytes)
 
     elif algorithm == uproot.const.kLZMA:
@@ -154,10 +154,10 @@ def write(context, cursor, givenbytes, compression, key, keycursor, awkward=Fals
             cursor.write_fields(context._sink, _header, algo, method, c1, c2, c3, u1, u2, u3)
             cursor.write_data(context._sink, after_compressed)
             key.fNbytes += compressedbytes + 9
-            key.write(keycursor, context._sink, awkward)
+            key.write(keycursor, context._sink, isjagged)
         else:
             key.fNbytes += uncompressedbytes
-            key.write(keycursor, context._sink, awkward)
+            key.write(keycursor, context._sink, isjagged)
             cursor.write_data(context._sink, givenbytes)
 
     elif algorithm == uproot.const.kOldCompressionAlgo:

--- a/uproot/write/objects/TTree.py
+++ b/uproot/write/objects/TTree.py
@@ -103,9 +103,6 @@ class TTree(object):
         self._tree.write(context, cursor, name, key, copy(keycursor), util)
 
     def extend(self, branchdict):
-
-        #FIXME: Enforce that the inner array lengths of multiple jagged array having the same dependence are the same
-
         #Baskets need to be added to all the branches
         if len(branchdict) != len(self._branches):
             raise Exception("Basket data should be added to all branches")
@@ -115,6 +112,16 @@ class TTree(object):
         first = next(values)
         if all(len(first) == len(value) for value in values) == False:
             raise Exception("Baskets of all branches should have the same length")
+
+        #Check if length of jaggedarrays depending on the same lengths branch is the same
+        tempdict = {}
+        for key, value in branchdict.items():
+            if self._branches[key]._branch.dependence is not None:
+                if self._branches[key]._branch.dependence in tempdict.keys():
+                    if not ((tempdict[self._branches[key]._branch.dependence].counts == value.counts).all()):
+                        raise Exception("Lengths of jagged arrays depending on the same lengths branch should be the same")
+                else:
+                    tempdict[self._branches[key]._branch.dependence] = value
 
         #Convert to numpy arrays of required dtype
         for key, value in branchdict.items():

--- a/uproot/write/objects/TTree.py
+++ b/uproot/write/objects/TTree.py
@@ -119,7 +119,7 @@ class TTree(object):
 
         for key, value in branchdict.items():
             if isinstance(value, awkward.array.jagged.JaggedArray):
-                self._branches[key].newbasket(value, value.shape[0])
+                self._branches[key].newbasket(value)
             elif value.ndim == 1:
                 self._branches[key].newbasket(value)
             else:

--- a/uproot/write/objects/TTree.py
+++ b/uproot/write/objects/TTree.py
@@ -61,8 +61,14 @@ class TTree(object):
                 if isinstance(newtree.branches[name].type, str):
                     # FIXME: Cannot have different jagged arrays with same type but different endianness
                     temptype = newtree.branches[name].type[1:].encode()
+                    # FIXME: int8 cannot be read properly by ROOT yet
+                    if newtree.branches[name].type == "int8":
+                        raise NotImplementedError("int8 cannot be read properly by ROOT yet")
                 else:
                     temptype = newtree.branches[name].type.str[1:].encode()
+                    # FIXME: int8 cannot be read properly by ROOT yet
+                    if newtree.branches[name].type.str == "int8":
+                        raise NotImplementedError("int8 cannot be read properly by ROOT yet")
                 if temptype not in checker:
                     branch.awkwardpadder = b"[awkwardcountsarraycreatedbyuproot" + temptype + b"]"
                     checker += [temptype]

--- a/uproot/write/objects/TTree.py
+++ b/uproot/write/objects/TTree.py
@@ -22,13 +22,13 @@ from uproot.write.objects.util import Util
 
 class newbranch(object):
 
-    def __init__(self, type, title="", shape=(1,), dependence=None, **options):
+    def __init__(self, type, title="", shape=(1,), counter=None, **options):
         self.name = ""
         self.type = type
         self.title = title
         self.shape = shape
-        self.dependence = dependence
-        self._isdependence = False
+        self.counter = counter
+        self._iscounter = False
         if "compression" in options:
             self.compression = options["compression"]
             del options["compression"]
@@ -57,7 +57,7 @@ class TTree(object):
         for name, branch in newtree.branches.items():
             if isinstance(branch, newbranch) == False:
                 branch = newbranch(branch)
-            if branch.dependence is not None:
+            if branch.counter is not None:
                 if isinstance(newtree.branches[name].type, str):
                     # FIXME: int8 and boolean cannot be read properly by ROOT yet
                     if newtree.branches[name].type == "int8" or newtree.branches[name].type == numpy.dtype("int8"):
@@ -70,23 +70,23 @@ class TTree(object):
                         raise NotImplementedError("int8 cannot be read properly by ROOT yet")
                     elif "?" in newtree.branches[name].type.str or newtree.branches[name].type.str == numpy.dtype(">?") or newtree.branches[name].type.str == numpy.dtype("<?"):
                         raise NotImplementedError("Booleans cannot be read properly by ROOT yet")
-                if branch.dependence not in checker:
-                    checker += [branch.dependence]
-                    if branch.dependence not in newtree.branches.keys():
+                if branch.counter not in checker:
+                    checker += [branch.counter]
+                    if branch.counter not in newtree.branches.keys():
                         dummybranch = newbranch(">i4")
-                        dummybranch._isdependence = True
+                        dummybranch._iscounter = True
                         compression = getattr(dummybranch, "compression", getattr(newtree, "compression", file.compression))
-                        self._branches[branch.dependence] = TBranch(branch.dependence, dummybranch, compression, self, file)
-                        self._tree.fields["_fLeaves"].append(self._branches[branch.dependence]._branch.fields["_fLeaves"])
-                        self._tree.fields["_fBranches"].append(self._branches[branch.dependence]._branch)
+                        self._branches[branch.counter] = TBranch(branch.counter, dummybranch, compression, self, file)
+                        self._tree.fields["_fLeaves"].append(self._branches[branch.counter]._branch.fields["_fLeaves"])
+                        self._tree.fields["_fBranches"].append(self._branches[branch.counter]._branch)
                     else:
-                        raise Exception(branch.dependence, " will be created automatically. Do not create it manually.")
+                        raise Exception(branch.counter, " will be created automatically. Do not create it manually.")
             compression = getattr(branch, "compression", getattr(newtree, "compression", file.compression))
             self._branches[name] = TBranch(name, branch, compression, self, file)
             self._tree.fields["_fLeaves"].append(self._branches[name]._branch.fields["_fLeaves"])
             self._tree.fields["_fBranches"].append(self._branches[name]._branch)
-            if branch.dependence is not None:
-                self._branches[name]._branch._awkwardbranch = self._branches[branch.dependence]._branch.fields["_fLeaves"]
+            if branch.counter is not None:
+                self._branches[name]._branch._awkwardbranch = self._branches[branch.counter]._branch.fields["_fLeaves"]
 
     def __getitem__(self, name):
         return self._branches[name]
@@ -116,12 +116,12 @@ class TTree(object):
         #Check if length of jaggedarrays depending on the same lengths branch is the same
         tempdict = {}
         for key, value in branchdict.items():
-            if self._branches[key]._branch.dependence is not None:
-                if self._branches[key]._branch.dependence in tempdict.keys():
-                    if not ((tempdict[self._branches[key]._branch.dependence].counts == value.counts).all()):
+            if self._branches[key]._branch.counter is not None:
+                if self._branches[key]._branch.counter in tempdict.keys():
+                    if not ((tempdict[self._branches[key]._branch.counter].counts == value.counts).all()):
                         raise Exception("Lengths of jagged arrays depending on the same lengths branch should be the same")
                 else:
-                    tempdict[self._branches[key]._branch.dependence] = value
+                    tempdict[self._branches[key]._branch.counter] = value
 
         #Convert to numpy arrays of required dtype
         for key, value in branchdict.items():
@@ -366,7 +366,7 @@ class TBranch(object):
             offsetbytes += [0]
             offsetbytes = numpy.array(offsetbytes, dtype=">i4").tostring()
             uproot.write.compress.write(self._branch.file, cursor, offsetbytes, self._branch.compression, key,
-                                        copy(keycursor), awkward=True)
+                                        copy(keycursor), isjagged=True)
 
         self._branch.file._expandfile(cursor)
 
@@ -376,7 +376,7 @@ class TBranch(object):
         self._treelvl1._tree.fields["_fTotBytes"] += self._branch.fields["_fTotBytes"]
         self._treelvl1._tree.fields["_fZipBytes"] += self._branch.fields["_fZipBytes"]
         self._branch.fields["_fBasketBytes"][self._branch.fields["_fWriteBasket"] - 1] = key.fNbytes
-        if self._branch.dependence and ((len(items[-1])*4) > 10):
+        if self._branch.counter and ((len(items[-1])*4) > 10):
             self._branch.fields["_fEntryOffsetLen"] = len(items[-1])*4
             self._branch._fentryoffsetlencursor.update_fields(self._branch.file._sink, self._branch._format_tbranch112, self._branch.fields["_fEntryOffsetLen"])
         self._treelvl1._tree.size_cursor.update_fields(self._branch.file._sink, self._tree_size, self._treelvl1._tree.fields["_fEntries"],
@@ -753,20 +753,20 @@ class TBranchImpl(object):
         self.type = numpy.dtype(branchobj.type).newbyteorder(">")
         self.shape = branchobj.shape
         self.compression = compression
-        self.dependence = branchobj.dependence
-        if self.dependence:
-            self.awkwardpadder = b"[" + self.dependence.encode("utf-8") + b"]"
+        self.counter = branchobj.counter
+        if self.counter:
+            self.awkwardpadder = b"[" + self.counter.encode("utf-8") + b"]"
         else:
             self.awkwardpadder = b""
         self._awkwardbranch = None
-        self._isdependence = branchobj._isdependence
+        self._iscounter = branchobj._iscounter
         self.util = None
         self.keycursor = None
         self.file = file
 
         self.fields = {"_fCompress": 100,
                        "_fBasketSize": 32000,
-                       "_fEntryOffsetLen": 10 if self.dependence else 0,
+                       "_fEntryOffsetLen": 10 if self.counter else 0,
                        "_fWriteBasket": 0,  # Number of baskets
                        "_fOffset": 0,
                        "_fMaxBaskets": 50,
@@ -889,13 +889,13 @@ class TBranchImpl(object):
                 fLen = fLen*self.shape[i]
         fLenType = numpy.dtype(self.type).itemsize
         fOffset = 0
-        if self._isdependence:
+        if self._iscounter:
             fIsRange = True
         else:
             fIsRange = False
         fIsUnsigned = False
         fLeafCount = None
-        if self.dependence:
+        if self.counter:
             buff = (self.put_tnamed(cursor, self.name, self.title + self.awkwardpadder) +
                     cursor.put_fields(self._format_tleaf1, fLen, fLenType, fOffset, fIsRange, fIsUnsigned) +
                     self.util.put_objany(cursor, (self._awkwardbranch[0], self._awkwardbranch[1]), self.keycursor))
@@ -913,7 +913,7 @@ class TBranchImpl(object):
         cursor.skip(self._format_cntvers.size)
         vers = 1
         fMinimum = 0
-        if self._isdependence:
+        if self._iscounter:
             fMaximum = min(numpy.iinfo(self.type).max, 1000) # FIXME: Make updateble
         else:
             fMaximum = 0
@@ -928,7 +928,7 @@ class TBranchImpl(object):
         cursor.skip(self._format_cntvers.size)
         vers = 1
         fMinimum = 0
-        if self._isdependence:
+        if self._iscounter:
             fMaximum = min(numpy.iinfo(self.type).max, 1000) # FIXME: Make updateble
         else:
             fMaximum = 0
@@ -943,7 +943,7 @@ class TBranchImpl(object):
         cursor.skip(self._format_cntvers.size)
         vers = 1
         fMinimum = 0
-        if self._isdependence:
+        if self._iscounter:
             fMaximum = 1000 # FIXME: Make updateble or set to maximum possible value
         else:
             fMaximum = 0
@@ -958,7 +958,7 @@ class TBranchImpl(object):
         cursor.skip(self._format_cntvers.size)
         vers = 1
         fMinimum = 0
-        if self._isdependence:
+        if self._iscounter:
             fMaximum = 1000 # FIXME: Make updateble or set to maximum possible value
         else:
             fMaximum = 0
@@ -973,7 +973,7 @@ class TBranchImpl(object):
         cursor.skip(self._format_cntvers.size)
         vers = 1
         fMinimum = 0
-        if self._isdependence:
+        if self._iscounter:
             fMaximum = min(numpy.iinfo(self.type).max, 1000) # FIXME: Make updateble
         else:
             fMaximum = 0
@@ -988,7 +988,7 @@ class TBranchImpl(object):
         cursor.skip(self._format_cntvers.size)
         vers = 1
         fMinimum = 0
-        if self._isdependence:
+        if self._iscounter:
             fMaximum = min(numpy.iinfo(self.type).max, 1000) # FIXME: Make updateble
         else:
             fMaximum = 0
@@ -1003,7 +1003,7 @@ class TBranchImpl(object):
         cursor.skip(self._format_cntvers.size)
         vers = 1
         fMinimum = 0
-        if self._isdependence:
+        if self._iscounter:
             fMaximum = min(numpy.iinfo(self.type).max, 1000) # FIXME: Make updateble
         else:
             fMaximum = 0
@@ -1054,7 +1054,7 @@ class TBranchImpl(object):
         copy_cursor = copy(cursor)
         cursor.skip(self._format_cntvers.size)
         vers = 13
-        if self.dependence:
+        if self.counter:
             buff = (self.put_tnamed(cursor, self.name, self.nametitle[:-2] + self.awkwardpadder + self.nametitle[-2:], hexbytes=numpy.uint32(0x03400000)) +
                     self.put_tattfill(cursor))
         else:


### PR DESCRIPTION
Fixes #354

The user interface is described in the tests. In particular to be noted is the new `dependence` flag. For eg - https://github.com/scikit-hep/uproot/compare/write-jagged#diff-5f81591ed2ee25a817de2554fd35f608R1861

Writing Jagged Arrays of the `int8` datatype is a little bit tricky and does not work yet - I am facing some difficulties in even getting the numbers out of a file created by ROOT. (This is for when using ROOT to read the values. uproot can read out the values correctly, even for the Jagged Arrays of type `int8` written by uproot) Also, since uproot reads the data correctly, that makes it trickier to debug. 

Weirdly, the travis test for reading a jagged array branch of type `>i8` created by uproot, using ROOT fails - https://travis-ci.org/github/scikit-hep/uproot/jobs/679767938#L1994. The weird part is that it always passes on my local system(ROOT master) whereas it always fails on Travis(ROOT from conda). I would really appreciate any help in debugging this.

An update to the README should probably accompany this once the user interface has been finalised. 