### PR TITLE
Rename counter to size in TBranch UI

### DIFF
--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -1867,7 +1867,7 @@ def test_jagged_i4(tmp_path):
                           [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i4"), counter="n")})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i4"), size="n")})
         f["t"].extend({"branch": a, "n": [1, 2, 3]})
 
     f = ROOT.TFile.Open(filename)
@@ -1883,7 +1883,7 @@ def test_jagged_uproot_i4(tmp_path):
                           [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i4"), counter="n")})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i4"), size="n")})
         f["t"].extend({"branch": a, "n": [1, 2, 3]})
 
     f = uproot.open(filename)
@@ -1901,7 +1901,7 @@ def test_jagged_i8(tmp_path):
                           [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i8"), counter="n")})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i8"), size="n")})
         f["t"].extend({"branch": a, "n": [1, 2, 3]})
 
     ROOT.gInterpreter.Declare("""
@@ -1936,7 +1936,7 @@ def test_jagged_uproot_i8(tmp_path):
                           [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i8"), counter="n")})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i8"), size="n")})
         f["t"].extend({"branch": a, "n": [1, 2, 3]})
 
     f = uproot.open(filename)
@@ -1953,7 +1953,7 @@ def test_jagged_f8(tmp_path):
                           [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">f8"), counter="n")})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">f8"), size="n")})
         f["t"].extend({"branch": a, "n": [1, 2, 3]})
 
     f = ROOT.TFile.Open(filename)
@@ -1969,7 +1969,7 @@ def test_jagged_uproot_f8(tmp_path):
                           [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">f8"), counter="n")})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">f8"), size="n")})
         f["t"].extend({"branch": a, "n": [1, 2, 3]})
 
     f = uproot.open(filename)
@@ -1986,7 +1986,7 @@ def test_jagged_f4(tmp_path):
                           [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">f4"), counter="n")})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">f4"), size="n")})
         f["t"].extend({"branch": a, "n": [1, 2, 3]})
 
     f = ROOT.TFile.Open(filename)
@@ -2002,7 +2002,7 @@ def test_jagged_uproot_f4(tmp_path):
                           [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">f4"), counter="n")})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">f4"), size="n")})
         f["t"].extend({"branch": a, "n": [1, 2, 3]})
 
     f = uproot.open(filename)
@@ -2019,7 +2019,7 @@ def test_jagged_i2(tmp_path):
                           [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i2"), counter="n")})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i2"), size="n")})
         f["t"].extend({"branch": a, "n": [1, 2, 3]})
 
     f = ROOT.TFile.Open(filename)
@@ -2035,7 +2035,7 @@ def test_jagged_uproot_i2(tmp_path):
                           [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i2"), counter="n")})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i2"), size="n")})
         f["t"].extend({"branch": a, "n": [1, 2, 3]})
 
     f = uproot.open(filename)
@@ -2054,8 +2054,8 @@ def test_jagged_i2_multiple_sametype(tmp_path):
                           [7, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch1": uproot.newbranch(numpy.dtype(">i2"), counter="n"),
-                                 "branch2": uproot.newbranch(numpy.dtype(">i2"), counter="n")})
+        f["t"] = uproot.newtree({"branch1": uproot.newbranch(numpy.dtype(">i2"), size="n"),
+                                 "branch2": uproot.newbranch(numpy.dtype(">i2"), size="n")})
         f["t"].extend({"branch1": a,
                        "branch2": b,
                        "n": [1, 2]})
@@ -2076,8 +2076,8 @@ def test_jagged_multiple_difftype(tmp_path):
                           [7, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch1": uproot.newbranch(numpy.dtype(">i2"), counter="n"),
-                                 "branch2": uproot.newbranch(numpy.dtype(">i4"), counter="n")})
+        f["t"] = uproot.newtree({"branch1": uproot.newbranch(numpy.dtype(">i2"), size="n"),
+                                 "branch2": uproot.newbranch(numpy.dtype(">i4"), size="n")})
         f["t"].extend({"branch1": a,
                        "branch2": b,
                        "n": [1, 2]})
@@ -2098,8 +2098,8 @@ def test_jagged_i2_multiple_difflen(tmp_path):
                           [10, 11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch1": uproot.newbranch(numpy.dtype(">i2"), counter="n1"),
-                                 "branch2": uproot.newbranch(numpy.dtype(">i2"), counter="n2")})
+        f["t"] = uproot.newtree({"branch1": uproot.newbranch(numpy.dtype(">i2"), size="n1"),
+                                 "branch2": uproot.newbranch(numpy.dtype(">i2"), size="n2")})
         f["t"].extend({"branch1": a,
                        "n1": [1, 2],
                        "branch2": b,
@@ -2126,7 +2126,7 @@ def test_jagged_i4_manybasket(tmp_path):
                                [11, 12]])
 
     with uproot.recreate(filename, compression=None) as f:
-        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i4"), counter="n")})
+        f["t"] = uproot.newtree({"branch": uproot.newbranch(numpy.dtype(">i4"), size="n")})
         f["t"].extend({"branch": a, "n": [1, 2, 3]})
         f["t"].extend({"branch": b, "n": [1, 2]})
 

--- a/uproot/write/objects/TTree.py
+++ b/uproot/write/objects/TTree.py
@@ -22,12 +22,12 @@ from uproot.write.objects.util import Util
 
 class newbranch(object):
 
-    def __init__(self, type, title="", shape=(1,), counter=None, **options):
+    def __init__(self, type, title="", shape=(1,), size=None, **options):
         self.name = ""
         self.type = type
         self.title = title
         self.shape = shape
-        self.counter = counter
+        self.counter = size
         self._iscounter = False
         if "compression" in options:
             self.compression = options["compression"]


### PR DESCRIPTION
Addresses @HDembinski 's comment - https://github.com/scikit-hep/uproot/pull/477/files#r419114287

@jpivarski should I also rename the corresponding attribute used internally like I did in https://github.com/scikit-hep/uproot/commit/b022cb974653a29d23ff6abcb720485b333a95f6 ? I am a little hesitant because size could mean other things.

There are 3 possibilities in my mind - 
1. Leave it as it is (the current state of this PR). 
2. Just rename the newbranch class' size attribute (and all references to it) so that users could first create the branch without specifying the `size` parameter and then do a `branch.size = ..` to change it. 
3. Replace all occurrences of 'counter' in the codebase(including the `_iscounter` class variable) with 'size'. 

Which one do you prefer?