### PR TITLE
NumPy's tostring -> tobytes warning (Python 3.8 stops suppressing deprecation warnings)

### DIFF
--- a/uproot/_util.py
+++ b/uproot/_util.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+
+# BSD 3-Clause License; see https://github.com/scikit-hep/uproot/blob/master/LICENSE
+
+from __future__ import absolute_import
+
+def _tobytes(x):
+    if hasattr(x, "tobytes"):
+        return x.tobytes()
+    else:
+        return x.tostring()

--- a/uproot/interp/objects.py
+++ b/uproot/interp/objects.py
@@ -15,6 +15,8 @@ import uproot.interp.interp
 import uproot.interp.numerical
 import uproot.interp.jagged
 
+from uproot._util import _tobytes
+
 class SimpleArray(object):
     def __init__(self, cls):
         self.cls = cls
@@ -131,7 +133,7 @@ class STLString(object):
         numitems = cursor.field(source, self._format1)
         if numitems == 255:
             numitems = cursor.field(source, self._format2)
-        return cursor.array(source, numitems, self.awkward.ObjectArray.CHARTYPE).tostring()
+        return _tobytes(cursor.array(source, numitems, self.awkward.ObjectArray.CHARTYPE))
 
 class Pointer(object):
     def __init__(self, cls):
@@ -404,7 +406,7 @@ class asstring(_variable):
     __metaclass__ = type.__new__(type, "type", (_variable.__metaclass__,), {})
 
     def __init__(self, skipbytes=1):
-        super(asstring, self).__init__(uproot.interp.jagged.asjagged(uproot.interp.numerical.asdtype(self.awkward.ObjectArray.CHARTYPE), skipbytes=skipbytes), lambda array: array.tostring())
+        super(asstring, self).__init__(uproot.interp.jagged.asjagged(uproot.interp.numerical.asdtype(self.awkward.ObjectArray.CHARTYPE), skipbytes=skipbytes), lambda array: _tobytes(array))
 
     def __repr__(self):
         return "asstring({0})".format("" if self.content.skipbytes == 1 else repr(self.content.skipbytes))

--- a/uproot/rootio.py
+++ b/uproot/rootio.py
@@ -23,6 +23,7 @@ from uproot.source.memmap import MemmapSource
 from uproot.source.xrootd import XRootDSource
 from uproot.source.http import HTTPSource
 from uproot.source.cursor import Cursor
+from uproot._util import _tobytes
 
 import uproot_methods.classes
 
@@ -1561,8 +1562,11 @@ class TRefArray(list, ROOTStreamedObject):
     def nbytes(self):
         return len(self) * self._dtype.itemsize
 
+    def tobytes(self):
+        return _tobytes(numpy.asarray(self, dtype=self._dtype))
+
     def tostring(self):
-        return numpy.asarray(self, dtype=self._dtype).tostring()
+        return self.tobytes()
 
 class TArray(list, ROOTStreamedObject):
     _classname = b"TArray"
@@ -1579,8 +1583,11 @@ class TArray(list, ROOTStreamedObject):
     def nbytes(self):
         return len(self) * self._dtype.itemsize
 
+    def tobytes(self):
+        return _tobytes(numpy.asarray(self, dtype=self._dtype))
+
     def tostring(self):
-        return numpy.asarray(self, dtype=self._dtype).tostring()
+        return self.tobytes()
 
 class TArrayC(TArray):
     _classname = b"TArrayC"

--- a/uproot/source/cursor.py
+++ b/uproot/source/cursor.py
@@ -9,6 +9,8 @@ import string
 
 import numpy
 
+from uproot._util import _tobytes
+
 class Cursor(object):
     # makes __doc__ attribute mutable before Python 3.3
     __metaclass__ = type.__new__(type, "type", (type,), {})
@@ -70,7 +72,7 @@ class Cursor(object):
             length = source.data(start, stop, numpy.dtype(">u4"))[0]
         start = self.index
         stop = self.index = start + length
-        return source.data(start, stop).tostring()
+        return _tobytes(source.data(start, stop))
 
     def cstring(self, source):
         char = None

--- a/uproot/write/objects/TTree.py
+++ b/uproot/write/objects/TTree.py
@@ -15,6 +15,7 @@ import uproot.const
 from uproot.rootio import _bytesid
 from uproot.rootio import nofilter
 from uproot.rootio import _memsize
+from uproot._util import _tobytes
 import uproot.write.compress
 import uproot.write.sink.cursor
 from uproot.write.TKey import BasketKey
@@ -334,15 +335,9 @@ class TBranch(object):
         if isinstance(items, awkward.array.jagged.JaggedArray):
             givenbytes = b""
             for i in range(items.shape[0]):
-                if sys.version_info.minor >= 8:
-                    givenbytes += numpy.array(items[i], dtype=self._branch.type).tobytes()
-                else:
-                    givenbytes += numpy.array(items[i], dtype=self._branch.type).tostring()
+                givenbytes += _tobytes(numpy.array(items[i], dtype=self._branch.type))
         else:
-            if sys.version_info.minor >= 8:
-                givenbytes = numpy.array(items, dtype=self._branch.type, copy=False).tobytes()
-            else:
-                givenbytes = numpy.array(items, dtype=self._branch.type, copy=False).tostring()
+            givenbytes = _tobytes(numpy.array(items, dtype=self._branch.type, copy=False))
 
         cursor = uproot.write.sink.cursor.Cursor(self._branch.file._fSeekFree)
         self._branch.fields["_fBasketSeek"][self._branch.fields["_fWriteBasket"] - 1] = cursor.index
@@ -372,10 +367,7 @@ class TBranch(object):
             for i in range(items.shape[0] - 1):
                 offsetbytes += [(len(items[i]) * numpy.dtype(self._branch.type).itemsize) + offsetbytes[-1]]
             offsetbytes += [0]
-            if sys.version_info.minor >= 8:
-                offsetbytes = numpy.array(offsetbytes, dtype=">i4").tobytes()
-            else:
-                offsetbytes = numpy.array(offsetbytes, dtype=">i4").tostring()
+            offsetbytes = _tobytes(numpy.array(offsetbytes, dtype=">i4"))
             uproot.write.compress.write(self._branch.file, cursor, offsetbytes, self._branch.compression, key,
                                         copy(keycursor), isjagged=True)
 

--- a/uproot/write/objects/TTree.py
+++ b/uproot/write/objects/TTree.py
@@ -334,9 +334,15 @@ class TBranch(object):
         if isinstance(items, awkward.array.jagged.JaggedArray):
             givenbytes = b""
             for i in range(items.shape[0]):
-                givenbytes += numpy.array(items[i], dtype=self._branch.type).tostring()
+                                if sys.version_info.minor >= 8:
+                    givenbytes += numpy.array(items[i], dtype=self._branch.type).tobytes()
+                else:
+                    givenbytes += numpy.array(items[i], dtype=self._branch.type).tostring()
         else:
-            givenbytes = numpy.array(items, dtype=self._branch.type, copy=False).tostring()
+            if sys.version_info.minor >= 8:
+                givenbytes = numpy.array(items, dtype=self._branch.type, copy=False).tobytes()
+            else:
+                givenbytes = numpy.array(items, dtype=self._branch.type, copy=False).tostring()
 
         cursor = uproot.write.sink.cursor.Cursor(self._branch.file._fSeekFree)
         self._branch.fields["_fBasketSeek"][self._branch.fields["_fWriteBasket"] - 1] = cursor.index
@@ -366,7 +372,10 @@ class TBranch(object):
             for i in range(items.shape[0] - 1):
                 offsetbytes += [(len(items[i]) * numpy.dtype(self._branch.type).itemsize) + offsetbytes[-1]]
             offsetbytes += [0]
-            offsetbytes = numpy.array(offsetbytes, dtype=">i4").tostring()
+             if sys.version_info.minor >= 8:
+                offsetbytes = numpy.array(offsetbytes, dtype=">i4").tobytes()
+            else:
+                offsetbytes = numpy.array(offsetbytes, dtype=">i4").tostring()
             uproot.write.compress.write(self._branch.file, cursor, offsetbytes, self._branch.compression, key,
                                         copy(keycursor), isjagged=True)
 

--- a/uproot/write/objects/TTree.py
+++ b/uproot/write/objects/TTree.py
@@ -334,7 +334,7 @@ class TBranch(object):
         if isinstance(items, awkward.array.jagged.JaggedArray):
             givenbytes = b""
             for i in range(items.shape[0]):
-                                if sys.version_info.minor >= 8:
+                if sys.version_info.minor >= 8:
                     givenbytes += numpy.array(items[i], dtype=self._branch.type).tobytes()
                 else:
                     givenbytes += numpy.array(items[i], dtype=self._branch.type).tostring()
@@ -372,7 +372,7 @@ class TBranch(object):
             for i in range(items.shape[0] - 1):
                 offsetbytes += [(len(items[i]) * numpy.dtype(self._branch.type).itemsize) + offsetbytes[-1]]
             offsetbytes += [0]
-             if sys.version_info.minor >= 8:
+            if sys.version_info.minor >= 8:
                 offsetbytes = numpy.array(offsetbytes, dtype=">i4").tobytes()
             else:
                 offsetbytes = numpy.array(offsetbytes, dtype=">i4").tostring()

--- a/uproot/write/sink/cursor.py
+++ b/uproot/write/sink/cursor.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import
 
 import struct
+import sys
 
 class Cursor(object):
     def __init__(self, index):
@@ -81,10 +82,16 @@ class Cursor(object):
 
     def put_array(self, data):
         self.index += data.nbytes
-        return data.tostring()
+        if sys.version_info >= 8:
+            return data.tobytes()
+        else:
+            return data.tostring()
 
     def update_array(self, sink, data):
-        sink.write(data.tostring(), self.index)
+        if sys.version_info >= 8:
+            sink.write(data.tobytes(), self.index)
+        else:
+            sink.write(data.tostring(), self.index)
 
     def write_array(self, sink, data):
         self.update_array(sink, data)

--- a/uproot/write/sink/cursor.py
+++ b/uproot/write/sink/cursor.py
@@ -82,13 +82,13 @@ class Cursor(object):
 
     def put_array(self, data):
         self.index += data.nbytes
-        if sys.version_info >= 8:
+        if sys.version_info.minor >= 8:
             return data.tobytes()
         else:
             return data.tostring()
 
     def update_array(self, sink, data):
-        if sys.version_info >= 8:
+        if sys.version_info.minor >= 8:
             sink.write(data.tobytes(), self.index)
         else:
             sink.write(data.tostring(), self.index)

--- a/uproot/write/sink/cursor.py
+++ b/uproot/write/sink/cursor.py
@@ -7,6 +7,8 @@ from __future__ import absolute_import
 import struct
 import sys
 
+from uproot._util import _tobytes
+
 class Cursor(object):
     def __init__(self, index):
         self.index = index
@@ -82,16 +84,10 @@ class Cursor(object):
 
     def put_array(self, data):
         self.index += data.nbytes
-        if sys.version_info.minor >= 8:
-            return data.tobytes()
-        else:
-            return data.tostring()
+        return _tobytes(data)
 
     def update_array(self, sink, data):
-        if sys.version_info.minor >= 8:
-            sink.write(data.tobytes(), self.index)
-        else:
-            sink.write(data.tostring(), self.index)
+        sink.write(_tobytes(data), self.index)
 
     def write_array(self, sink, data):
         self.update_array(sink, data)


### PR DESCRIPTION
Changed deprecated method `tostring()` with method `tobytes()` for compatibility with python versions newer than 3.8