### PR TITLE
Implemented TFileUpdate.bulk_write

### DIFF
--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -2135,7 +2135,7 @@ def test_jagged_i4_manybasket(tmp_path):
     for i, event in enumerate(tree):
         assert(numpy.all([x for x in event.branch] == tester[i]))
 
-def test_bulk_write(tmp_path):
+def test_update(tmp_path):
     filename = join(str(tmp_path), "example.root")
     testfile = join(str(tmp_path), "test.root")
     n = 3
@@ -2148,7 +2148,7 @@ def test_bulk_write(tmp_path):
     t = uproot.open(testfile)
     hist = t["hvar"]
     with uproot.recreate(filename, compression=None) as f:
-        f.bulk_write(("test%d" % i, hist) for i in range(n))
+        f.update(("test%d" % i, hist) for i in range(n))
 
     f = ROOT.TFile.Open(filename)
     for i in range(n):

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -2134,3 +2134,22 @@ def test_jagged_i4_manybasket(tmp_path):
     tree = f.Get("t")
     for i, event in enumerate(tree):
         assert(numpy.all([x for x in event.branch] == tester[i]))
+
+def test_bulk_write(tmp_path):
+    filename = join(str(tmp_path), "example.root")
+    testfile = join(str(tmp_path), "test.root")
+    n = 3
+
+    f = ROOT.TFile.Open(testfile, "RECREATE")
+    h = ROOT.TH1F("hvar", "title", 5, 1, 10)
+    h.Write()
+    f.Close()
+
+    t = uproot.open(testfile)
+    hist = t["hvar"]
+    with uproot.recreate(filename, compression=None) as f:
+        f.bulk_write(("test%d" % i, hist) for i in range(n))
+
+    f = ROOT.TFile.Open(filename)
+    for i in range(n):
+        assert f.Get("test%d" % i).GetNbinsX() == 5, i

--- a/uproot/write/TFile.py
+++ b/uproot/write/TFile.py
@@ -102,6 +102,54 @@ class TFileUpdate(object):
         self._rootdir.setkey(newkey)
         self._sink.flush()
 
+    def bulk_write(self, content):
+        self.util = Util()
+
+        cursor = uproot.write.sink.cursor.Cursor(self._fSeekFree)
+        for where, what in content:
+            where, cycle = self._normalizewhere(where)
+
+            isTTree = what.__class__.__name__ in ("newtree", "TTree")
+            assert not isTTree  # prevent TTree writing, otherwise migth invoke nasty magic
+            if not isTTree:
+                what = uproot_methods.convert.towriteable(what)
+            elif what.__class__.__name__ == "newtree":
+                what = TTree(where, what, self)
+
+            newkey = uproot.write.TKey.TKey(
+                fClassName=what._fClassName,
+                fName=where,
+                fTitle=what._fTitle,
+                fObjlen=0,
+                fSeekKey=cursor.index,
+                fSeekPdir=self._fBEGIN,
+                fCycle=cycle if cycle is not None else self._rootdir.newcycle(where),
+            )
+            if isTTree:
+                # Need to (re)attach the cycle number to allow getitem to access writable TTree
+                tree_where = where + b";" + str(newkey.fCycle).encode("utf-8")
+                self._treedict[tree_where] = what
+
+            newkeycursor = uproot.write.sink.cursor.Cursor(newkey.fSeekKey)
+            newkey.write(cursor, self._sink)
+            what._write(self, cursor, where, self.compression, newkey, newkeycursor, self.util)
+
+            # prevent overwrite (migth be excessive and actually work fine)
+            assert (newkey.fName, newkey.fCycle) not in self._rootdir.keys
+
+            self._rootdir.headkey.fObjlen += newkey.fKeylen
+            self._rootdir.keys[(newkey.fName, newkey.fCycle)] = newkey
+
+        # write (root) TDirectory
+        self._rootdir.fNbytesKeys = self._rootdir._nbyteskeys()
+        while self._rootdir.fNbytesKeys > self._rootdir.allocationbytes:
+            self._rootdir.allocationbytes *= self._rootdir.growfactor
+
+        self._rootdir.writekeys(cursor)
+
+        self._expandfile(cursor)
+        self._sink.flush()
+
     def __delitem__(self, where):
         where, cycle = self._normalizewhere(where)
         try:


### PR DESCRIPTION
This PR implements a `bulk_write` for `TFileUpdate`, which is useful for writing O(10^5) objects (i.e. histograms).
In such cases it avoids the performance degradation of the `__setitem__` way of writing, by delaying the update/write of the `TDirectory` entry until after all the `TKey`s have been added. In particular, this reduces accesses of `TKey.fKeylen` from O(n^2) to O(n).

Some details regarding this Implementation:
- currently prevents overwriting entries (existing name+cycle combinations) - but this might actually work fine
- always writes a new `TDirectory` (after all the objects), even if the current allocation is big enough (which is unlikely in the intended usage scenario)
- `TTree` writing was/is not tested

If/When the writing implementation supports delayed `TDirectory` updates this should not be needed anymore.