### PR TITLE
Update TTree.py

### DIFF
--- a/uproot3/write/objects/TTree.py
+++ b/uproot3/write/objects/TTree.py
@@ -333,9 +333,7 @@ class TBranch(object):
             self._branch.fields["_fEntryNumber"] = multidim
         self._branch.fields["_fBasketEntry"][self._branch.fields["_fWriteBasket"]] = self._branch.fields["_fEntries"]
         if isinstance(items, awkward0.array.jagged.JaggedArray):
-            givenbytes = b""
-            for i in range(items.shape[0]):
-                givenbytes += _tobytes(numpy.array(items[i], dtype=self._branch.type))
+            givenbytes = _tobytes(numpy.array(items.flatten(), dtype=self._branch.type, copy=False))
         else:
             givenbytes = _tobytes(numpy.array(items, dtype=self._branch.type, copy=False))
 


### PR DESCRIPTION
Changed the for-loop for the JaggedArray datatype to a version flattening the array. The for loops runtime scaled quadratically and was not possible to use for arrays with more than 1e5 entries.